### PR TITLE
feat: Add support for custom bottom overlay padding in post views

### DIFF
--- a/lib/presentation/screens/posts/ism_post_view.dart
+++ b/lib/presentation/screens/posts/ism_post_view.dart
@@ -17,11 +17,13 @@ class IsmPostView extends StatefulWidget {
     this.allowImplicitScrolling = false,
     this.onPageChanged,
     this.onTabChange,
+    this.bottomOverlayPadding,
   });
 
   final List<TabDataModel> tabDataModelList;
   final num? currentIndex;
   final bool? allowImplicitScrolling;
+  final double? bottomOverlayPadding;
   final Function(int, String)? onPageChanged;
   final Future<bool> Function(TabDataModel, int)? onTabChange;
 
@@ -217,6 +219,7 @@ class _PostViewState extends State<IsmPostView> with TickerProviderStateMixin {
         onLoadMore: tabData.onLoadMore,
         onTapCartIcon: tabData.onTapCartIcon,
         onRefresh: tabData.onRefresh,
+        bottomOverlayPadding: widget.bottomOverlayPadding,
         placeHolderWidget: tabData.placeHolderWidget,
         postSectionType: tabData.postSectionType,
         onTapPlaceHolder: () {

--- a/lib/presentation/screens/posts/ism_reels_video_player_view.dart
+++ b/lib/presentation/screens/posts/ism_reels_video_player_view.dart
@@ -54,6 +54,7 @@ class IsmReelsVideoPlayerView extends StatefulWidget {
     this.postStatus,
     this.isFirstPost,
     this.onTapTag,
+    this.bottomOverlayPadding,
   });
 
   final String? mediaUrl;
@@ -98,6 +99,7 @@ class IsmReelsVideoPlayerView extends StatefulWidget {
   final int? postStatus;
   final bool? isFirstPost;
   final Function(String tag)? onTapTag;
+  final double? bottomOverlayPadding;
 
   @override
   State<IsmReelsVideoPlayerView> createState() => _IsmReelsVideoPlayerViewState();
@@ -382,7 +384,7 @@ class _IsmReelsVideoPlayerViewState extends State<IsmReelsVideoPlayerView> {
       );
 
   Widget _buildRightSideActions() => Padding(
-        padding: IsrDimens.edgeInsets(bottom: IsrDimens.forty, right: IsrDimens.sixteen),
+        padding: IsrDimens.edgeInsets(bottom: (widget.bottomOverlayPadding ?? 0) + IsrDimens.forty, right: IsrDimens.sixteen),
         child: Column(
           mainAxisSize: MainAxisSize.min,
           mainAxisAlignment: MainAxisAlignment.end,
@@ -540,7 +542,7 @@ class _IsmReelsVideoPlayerViewState extends State<IsmReelsVideoPlayerView> {
 
   Widget _buildBottomSection() => Padding(
         padding: IsrDimens.edgeInsets(
-            left: IsrDimens.sixteen, right: IsrDimens.sixteen, bottom: IsrDimens.fifteen),
+            left: IsrDimens.sixteen, right: IsrDimens.sixteen, bottom: (widget.bottomOverlayPadding ?? 0) + IsrDimens.fifteen),
         child: Column(
           crossAxisAlignment: CrossAxisAlignment.start,
           mainAxisSize: MainAxisSize.min,

--- a/lib/presentation/screens/posts/post_item_widget.dart
+++ b/lib/presentation/screens/posts/post_item_widget.dart
@@ -32,6 +32,7 @@ class PostItemWidget extends StatefulWidget {
     this.allowImplicitScrolling = true,
     this.onPageChanged,
     this.onTapTag,
+    this.bottomOverlayPadding,
   });
 
   final Future<String?> Function()? onCreatePost;
@@ -56,6 +57,7 @@ class PostItemWidget extends StatefulWidget {
   final bool? allowImplicitScrolling;
   final Function(int, String)? onPageChanged;
   final Function(String tag, String postId)? onTapTag;
+  final double? bottomOverlayPadding;
 
   @override
   State<PostItemWidget> createState() => _PostItemWidgetState();
@@ -187,6 +189,7 @@ class _PostItemWidgetState extends State<PostItemWidget> {
           isCreatePostButtonVisible: widget.isCreatePostButtonVisible,
           thumbnail: _postList[index].thumbnailUrl1 ?? '',
           key: Key(_postList[index].postId ?? ''),
+          bottomOverlayPadding: widget.bottomOverlayPadding,
           onCreatePost: () async {
             if (widget.onCreatePost == null) return;
             final postDataModelJsonString = await widget.onCreatePost!();


### PR DESCRIPTION
- Introduces `bottomOverlayPadding` property to `IsmPostView`, `PostItemWidget`, and `IsmReelsVideoPlayerView`.
- Updates `IsmReelsVideoPlayerView` to apply the custom padding to both the right-side actions and the bottom section of the video player.
- Ensures the padding is propagated from the main post view through the widget tree to the individual reel players.