### PR TITLE
feat : now from app side we can pass custom loader

### DIFF
--- a/README.md
+++ b/README.md
@@ -246,7 +246,7 @@ Config and callbacks are set via **`IsrVideoReelConfig`** (or passed into `initi
 
 | Config                    | Purpose |
 |---------------------------|--------|
-| **`socialConfig`**        | Theme, toasts, dialogs, buttons, fonts, colors; optional **`GoogleCloudUpload`** (`credentialsJsonPath`, `bucketName`); **SocialCallBackConfig**: `onLoginInvoked`, optional `uploadMediaToCloud`, `convertToGumletUrl`. |
+| **`socialConfig`**        | Theme, toasts, dialogs, buttons, fonts, colors; app-wide loader override via `loaderBuilder`; optional **`GoogleCloudUpload`** (`credentialsJsonPath`, `bucketName`); **SocialCallBackConfig**: `onLoginInvoked`, optional `uploadMediaToCloud`, `convertToGumletUrl`. |
 | **`postConfig`**          | Post UI (overlay, actions, media indicator, profile, description, location, shop, follow button); **PostCallBackConfig**: save/like/follow/share/comment/profile/tag-product/post-changed. |
 | **`tabConfig`**           | Tab bar, back button, loading, status bar; **TabCallBackConfig**: `onChangeOfTab`, `onReelsLoaded`, `getEmptyScreen`. |
 | **`commentConfig`**       | Comment bottom sheet, header, item, reply field, placeholder, more options. |
@@ -281,6 +281,35 @@ socialConfig: SocialConfig(
 | `bucketName` | Target Google Cloud Storage bucket name. |
 
 You can customize each config’s sub-properties (e.g. `ThemeConfig`, `ToastConfig`, `ButtonConfig`, `GoogleCloudUpload`, `PostUIConfig`, etc.) as needed; see the respective model classes in the SDK for full options.
+
+### Reuse one loader across complete SDK
+
+Provide `loaderBuilder` in `SocialConfig` to use your app loader in all SDK loading states (dialog loaders and inline loaders):
+
+```dart
+socialConfig: SocialConfig(
+  loaderBuilder: (
+    context, {
+    bool isDialog = false,
+    String? message,
+    LoaderType? loaderType,
+    bool isAdaptive = true,
+  }) {
+    return Center(
+      child: Column(
+        mainAxisSize: MainAxisSize.min,
+        children: [
+          const CircularProgressIndicator(),
+          if (isDialog && message != null) ...[
+            const SizedBox(height: 12),
+            Text(message),
+          ],
+        ],
+      ),
+    );
+  },
+),
+```
 
 ---
 

--- a/lib/domain/models/social_config.dart
+++ b/lib/domain/models/social_config.dart
@@ -1,7 +1,24 @@
 import 'dart:io' show File;
 
 import 'package:flutter/material.dart';
-import 'package:ism_video_reel_player/utils/enums.dart' show ButtonType, MediaType;
+import 'package:ism_video_reel_player/utils/enums.dart'
+    show ButtonType, LoaderType, MediaType;
+
+/// App-provided loader builder used across SDK screens/dialogs.
+///
+/// The same callback is reused by:
+/// - `AppLoader` (dialog and full-screen loaders)
+/// - `Utility.loaderWidget()` (inline loaders in lists/cards/placeholders)
+///
+/// Returning a widget here lets host apps keep one consistent loading UI
+/// without changing SDK internals.
+typedef SdkLoaderBuilder = Widget Function(
+  BuildContext context, {
+  bool isDialog,
+  String? message,
+  LoaderType? loaderType,
+  bool isAdaptive,
+});
 
 /// Main configuration class for social features in the SDK.
 ///
@@ -71,6 +88,7 @@ import 'package:ism_video_reel_player/utils/enums.dart' show ButtonType, MediaTy
 class SocialConfig {
   const SocialConfig({
     this.socialCallBackConfig,
+    this.loaderBuilder,
     this.themeConfig,
     this.toastConfig,
     this.dialogConfig,
@@ -84,6 +102,13 @@ class SocialConfig {
   });
 
   final SocialCallBackConfig? socialCallBackConfig;
+
+  /// App-side loader builder reused across the complete SDK.
+  ///
+  /// If provided, the SDK uses this loader for both dialog-level and inline
+  /// loading states. If omitted, SDK falls back to default `AppLoader` /
+  /// `CircularProgressIndicator` behavior.
+  final SdkLoaderBuilder? loaderBuilder;
   final ThemeConfig? themeConfig;
   final ToastConfig? toastConfig;
   final DialogConfig? dialogConfig;
@@ -128,6 +153,7 @@ class SocialConfig {
 
   SocialConfig copyWith({
     SocialCallBackConfig? socialCallBackConfig,
+    SdkLoaderBuilder? loaderBuilder,
     ThemeConfig? themeConfig,
     ToastConfig? toastConfig,
     DialogConfig? dialogConfig,
@@ -141,6 +167,7 @@ class SocialConfig {
   }) =>
       SocialConfig(
         socialCallBackConfig: socialCallBackConfig ?? this.socialCallBackConfig,
+        loaderBuilder: loaderBuilder ?? this.loaderBuilder,
         themeConfig: themeConfig ?? this.themeConfig,
         toastConfig: toastConfig ?? this.toastConfig,
         dialogConfig: dialogConfig ?? this.dialogConfig,

--- a/lib/presentation/screens/widgets/app_loader.dart
+++ b/lib/presentation/screens/widgets/app_loader.dart
@@ -1,4 +1,5 @@
 import 'package:flutter/material.dart';
+import 'package:ism_video_reel_player/isr_video_reel_config.dart';
 import 'package:ism_video_reel_player/res/res.dart';
 import 'package:ism_video_reel_player/utils/utils.dart';
 
@@ -15,36 +16,57 @@ class AppLoader extends StatelessWidget {
   final LoaderType? loaderType;
 
   @override
-  Widget build(BuildContext context) => Center(
-        child: loaderType == LoaderType.normal
-            ? const CircularProgressIndicator(
-                color: Colors.blue,
-                strokeWidth: 3,
-              )
-            : Card(
-                elevation: isDialog ? null : 0,
-                color: Colors.white,
-                child: Padding(
-                  padding: isDialog && message != null
-                      ? IsrDimens.edgeInsetsAll(IsrDimens.sixteen)
-                      : IsrDimens.edgeInsetsAll(IsrDimens.eight),
-                  child: Row(
-                    crossAxisAlignment: CrossAxisAlignment.center,
-                    mainAxisSize: MainAxisSize.min,
-                    children: [
-                      const CircularProgressIndicator(
-                        color: Colors.blue,
-                        strokeWidth: 3,
-                      ),
-                      if (isDialog && message != null) ...[
-                        IsrDimens.boxWidth(IsrDimens.sixteen),
-                        Text(
-                          message!,
-                        ),
-                      ],
-                    ],
-                  ),
-                ),
-              ),
+  Widget build(BuildContext context) {
+    final appLoaderBuilder = IsrVideoReelConfig.socialConfig.loaderBuilder;
+    if (appLoaderBuilder != null) {
+      // Reuse host app loader everywhere SDK uses AppLoader.
+      return appLoaderBuilder(
+        context,
+        isDialog: isDialog,
+        message: message,
+        loaderType: loaderType,
+        isAdaptive: false,
       );
+    }
+
+    return Center(
+      child: _buildDefaultLoader(),
+    );
+  }
+
+  Widget _buildDefaultLoader() {
+    final indicator = const CircularProgressIndicator(
+      color: Colors.blue,
+      strokeWidth: 3,
+    );
+
+    // Keep transparent loader truly transparent (no white card).
+    if (loaderType == LoaderType.normal ||
+        loaderType == LoaderType.withoutBackground) {
+      return indicator;
+    }
+
+    return Card(
+      elevation: isDialog ? null : 0,
+      color: Colors.white,
+      child: Padding(
+        padding: isDialog && message != null
+            ? IsrDimens.edgeInsetsAll(IsrDimens.sixteen)
+            : IsrDimens.edgeInsetsAll(IsrDimens.eight),
+        child: Row(
+          crossAxisAlignment: CrossAxisAlignment.center,
+          mainAxisSize: MainAxisSize.min,
+          children: [
+            indicator,
+            if (isDialog && message != null) ...[
+              IsrDimens.boxWidth(IsrDimens.sixteen),
+              Text(
+                message!,
+              ),
+            ],
+          ],
+        ),
+      ),
+    );
+  }
 }

--- a/lib/utils/utility.dart
+++ b/lib/utils/utility.dart
@@ -428,13 +428,29 @@ class Utility {
     }
   }
 
-  static Widget loaderWidget({bool? isAdaptive = true}) => Center(
-        child: isAdaptive == true
-            ? CircularProgressIndicator.adaptive(
-                backgroundColor: IsrColors.appColor,
-        )
-            : CircularProgressIndicator(color: IsrColors.appColor),
+  static Widget loaderWidget({bool? isAdaptive = true}) {
+    final appLoaderBuilder = IsrVideoReelConfig.socialConfig.loaderBuilder;
+    if (appLoaderBuilder != null) {
+      final loaderContext = context ?? IsrVideoReelConfig.buildContext;
+      if (loaderContext == null) {
+        return const Center(child: CircularProgressIndicator());
+      }
+      // Reuse app-side loader for inline placeholders as well.
+      return appLoaderBuilder(
+        loaderContext,
+        isDialog: false,
+        loaderType: LoaderType.normal,
+        isAdaptive: isAdaptive ?? true,
       );
+    }
+    return Center(
+      child: isAdaptive == true
+          ? CircularProgressIndicator.adaptive(
+              backgroundColor: IsrColors.appColor,
+            )
+          : CircularProgressIndicator(color: IsrColors.appColor),
+    );
+  }
 
   /// get formated date
   static String getFormattedDateWithNumberOfDays(int? numberOfDays,


### PR DESCRIPTION
<!-- kody-pr-summary:start -->
This pull request introduces a customizable, app-wide loader builder feature in the SDK. Developers can now pass a `loaderBuilder` callback within the `socialConfig` configuration, enabling them to define a consistent custom loading widget that is used across all SDK loading states, including dialogs and inline placeholders. If provided, this custom loader replaces the default `CircularProgressIndicator` and card-based loaders, allowing for a unified and branded loading experience throughout the app. The change also updates related components, such as `AppLoader` and utility functions, to utilize this custom loader when available, ensuring seamless integration and consistent UI during loading processes.
<!-- kody-pr-summary:end -->