### PR TITLE
feat: Implement timeline post fetching in `IsmDataProvider`

### DIFF
--- a/lib/data/ism_data_provider.dart
+++ b/lib/data/ism_data_provider.dart
@@ -28,6 +28,9 @@ class IsmDataProvider {
   GetTrendingPostUseCase get _getTrendingPostUseCase =>
       IsmInjectionUtils.getUseCase<GetTrendingPostUseCase>();
 
+  GetTimelinePostUseCase get _getTimelinePostUseCase =>
+      IsmInjectionUtils.getUseCase<GetTimelinePostUseCase>();
+
   SocialUserProfileUseCase get _socialUserProfileUseCase =>
       IsmInjectionUtils.getUseCase<SocialUserProfileUseCase>();
 
@@ -61,7 +64,7 @@ class IsmDataProvider {
 
   Future<void> fetchTrendingPost({
     String? cursor,
-    required int limit,
+    int limit = 20,
     bool isLoading = false,
     Function(String, int)? onSuccess,
     Function(String, int)? onError,
@@ -69,6 +72,22 @@ class IsmDataProvider {
     await _executeApiCall(
       apiCall: () => _getTrendingPostUseCase.executeGetTrendingPost(
           isLoading: isLoading, limit: limit, cursor: cursor),
+      toJson: (data) => data?.toMap() ?? {},
+      onSuccess: onSuccess,
+      onError: onError,
+    );
+  }
+
+  Future<void> fetchFollowingPost({
+    int limit = 20,
+    int page = 1,
+    bool isLoading = false,
+    Function(String, int)? onSuccess,
+    Function(String, int)? onError,
+  }) async {
+    await _executeApiCall(
+      apiCall: () => _getTimelinePostUseCase.executeTimeLinePost(
+          isLoading: isLoading, page: page, pageLimit: limit),
       toJson: (data) => data?.toMap() ?? {},
       onSuccess: onSuccess,
       onError: onError,


### PR DESCRIPTION
<!-- kody-pr-summary:start -->
This pull request introduces functionality to fetch timeline posts within the `IsmDataProvider`. Specifically, it adds a new method `fetchFollowingPost` that retrieves posts from the user's timeline or following feed, utilizing the newly injected `GetTimelinePostUseCase`. Additionally, it sets a default limit for trending posts and prepares the provider to handle timeline data, enabling the app to support a social feed feature based on user followings.
<!-- kody-pr-summary:end -->