### PR TITLE
feat: Update post navigation to use ReelsPlayer

### DIFF
--- a/lib/presentation/screens/posts/collections/collection_details_view.dart
+++ b/lib/presentation/screens/posts/collections/collection_details_view.dart
@@ -560,7 +560,13 @@ class _CollectionDetailsViewState extends State<CollectionDetailsView> {
             return TapHandler(
               key: ValueKey('post_${post.id}'),
               onTap: () {
-                // Navigate to post detail
+                IsrAppNavigator.navigateToReelsPlayer(
+                  context,
+                  postDataList: _posts,
+                  startingPostIndex: index,
+                  postSectionType: PostSectionType.singlePost,
+                  postId: post.id ?? '',
+                );
               },
               onLongPress: () => _showPostOptions(post),
               child: _buildPostCard(post, index),


### PR DESCRIPTION
<!-- kody-pr-summary:start -->
This pull request updates the post navigation behavior within the collection details view to utilize the new `ReelsPlayer` navigation method. Instead of navigating to a standard post detail screen, tapping on a post now opens the post in a ReelsPlayer, allowing for an enhanced media viewing experience. This change improves the user experience by providing a more immersive and consistent media playback interface when interacting with posts in collections.
<!-- kody-pr-summary:end -->