### PR TITLE
Feature/purchase post flow

### DIFF
--- a/example/lib/domain/models/request/create_post_request.dart
+++ b/example/lib/domain/models/request/create_post_request.dart
@@ -161,16 +161,24 @@ class PostSetting {
     return null;
   }
 
-  Map<String, dynamic> toJson() => {
-        'advance_interval': advanceInterval,
-        'age_restriction': ageRestriction,
-        'auto_advance': autoAdvance,
-        'comments_enabled': commentsEnabled,
-        'duet_enabled': duetEnabled,
-        'save_enabled': saveEnabled,
-        'stitch_enabled': stitchEnabled,
-        if (isPaid != null) 'is_paid': isPaid,
-        if (priceAmount != null) 'price_amount': priceAmount,
-        if (priceCurrency != null) 'price_currency': priceCurrency,
-      };
+  Map<String, dynamic> toJson() {
+    final payload = <String, dynamic>{
+      'advance_interval': advanceInterval,
+      'age_restriction': ageRestriction,
+      'auto_advance': autoAdvance,
+      'comments_enabled': commentsEnabled,
+      'duet_enabled': duetEnabled,
+      'save_enabled': saveEnabled,
+      'stitch_enabled': stitchEnabled,
+    };
+    final shouldSendPaidFields = isPaid == true &&
+        priceAmount != null &&
+        (priceCurrency?.trim().isNotEmpty ?? false);
+    if (shouldSendPaidFields) {
+      payload['is_paid'] = true;
+      payload['price_amount'] = priceAmount;
+      payload['price_currency'] = priceCurrency;
+    }
+    return payload;
+  }
 }

--- a/example/lib/domain/models/request/create_post_request.dart
+++ b/example/lib/domain/models/request/create_post_request.dart
@@ -84,18 +84,30 @@ class CreatePostRequest {
 }
 
 class PostSetting {
-  factory PostSetting.fromJson(Map<String, dynamic> json) => PostSetting(
-        advanceInterval: json['advance_interval'] as num? ?? 0,
-        ageRestriction: json['age_restriction'] as bool? ?? false,
-        autoAdvance: json['auto_advance'] as bool? ?? false,
-        commentsEnabled: json['comments_enabled'] as bool? ?? false,
-        duetEnabled: json['duet_enabled'] as bool? ?? false,
-        saveEnabled: json['save_enabled'] as bool? ?? false,
-        stitchEnabled: json['stitch_enabled'] as bool? ?? false,
-        isPaid: json['is_paid'] as bool?,
-        priceAmount: json['price_amount'],
-        priceCurrency: json['price_currency'] as String?,
-      );
+  factory PostSetting.fromJson(Map<String, dynamic> json) {
+    final isPaid = _readBool(json['is_paid'], key: 'is_paid');
+    final priceAmount =
+        _readPriceAmount(json['price_amount'], key: 'price_amount');
+    final normalizedIsPaid =
+        (isPaid == true && priceAmount == null) ? false : isPaid;
+
+    return PostSetting(
+      advanceInterval:
+          _readNum(json['advance_interval'], key: 'advance_interval') ?? 0,
+      ageRestriction:
+          _readBool(json['age_restriction'], key: 'age_restriction') ?? false,
+      autoAdvance: _readBool(json['auto_advance'], key: 'auto_advance') ?? false,
+      commentsEnabled:
+          _readBool(json['comments_enabled'], key: 'comments_enabled') ?? false,
+      duetEnabled: _readBool(json['duet_enabled'], key: 'duet_enabled') ?? false,
+      saveEnabled: _readBool(json['save_enabled'], key: 'save_enabled') ?? false,
+      stitchEnabled:
+          _readBool(json['stitch_enabled'], key: 'stitch_enabled') ?? false,
+      isPaid: normalizedIsPaid,
+      priceAmount: priceAmount,
+      priceCurrency: json['price_currency'] as String?,
+    );
+  }
 
   PostSetting({
     this.advanceInterval,
@@ -120,6 +132,34 @@ class PostSetting {
   final bool? isPaid;
   final Object? priceAmount;
   final String? priceCurrency;
+
+  static bool? _readBool(dynamic value, {required String key}) {
+    if (value == null) return null;
+    if (value is bool) return value;
+    if (value is num) return value != 0;
+    if (value is String) {
+      final normalized = value.trim().toLowerCase();
+      if (normalized == 'true' || normalized == '1') return true;
+      if (normalized == 'false' || normalized == '0') return false;
+    }
+    return null;
+  }
+
+  static num? _readNum(dynamic value, {required String key}) {
+    if (value == null) return null;
+    if (value is num) return value;
+    if (value is String) {
+      final parsed = num.tryParse(value);
+      if (parsed != null) return parsed;
+    }
+    return null;
+  }
+
+  static Object? _readPriceAmount(dynamic value, {required String key}) {
+    if (value == null) return null;
+    if (value is num || value is String) return value;
+    return null;
+  }
 
   Map<String, dynamic> toJson() => {
         'advance_interval': advanceInterval,

--- a/example/lib/domain/models/request/create_post_request.dart
+++ b/example/lib/domain/models/request/create_post_request.dart
@@ -92,6 +92,9 @@ class PostSetting {
         duetEnabled: json['duet_enabled'] as bool? ?? false,
         saveEnabled: json['save_enabled'] as bool? ?? false,
         stitchEnabled: json['stitch_enabled'] as bool? ?? false,
+        isPaid: json['is_paid'] as bool?,
+        priceAmount: json['price_amount'],
+        priceCurrency: json['price_currency'] as String?,
       );
 
   PostSetting({
@@ -102,6 +105,9 @@ class PostSetting {
     this.duetEnabled,
     this.saveEnabled,
     this.stitchEnabled,
+    this.isPaid,
+    this.priceAmount,
+    this.priceCurrency,
   });
 
   final num? advanceInterval;
@@ -111,6 +117,9 @@ class PostSetting {
   final bool? duetEnabled;
   final bool? saveEnabled;
   final bool? stitchEnabled;
+  final bool? isPaid;
+  final Object? priceAmount;
+  final String? priceCurrency;
 
   Map<String, dynamic> toJson() => {
         'advance_interval': advanceInterval,
@@ -120,5 +129,8 @@ class PostSetting {
         'duet_enabled': duetEnabled,
         'save_enabled': saveEnabled,
         'stitch_enabled': stitchEnabled,
+        if (isPaid != null) 'is_paid': isPaid,
+        if (priceAmount != null) 'price_amount': priceAmount,
+        if (priceCurrency != null) 'price_currency': priceCurrency,
       };
 }

--- a/lib/domain/models/create_edit_post_config.dart
+++ b/lib/domain/models/create_edit_post_config.dart
@@ -8,16 +8,25 @@ class CreateEditPostConfig {
     this.createEditPostCallBackConfig,
     this.createEditPostUIConfig,
     this.autoMoveToNextPost = true,
+    this.enablePaidPost = false,
+    this.paidPostCurrency = 'coin',
+    this.paidPostAmountSuggestions = const [10, 50, 100, 150],
   });
 
   final CreateEditPostCallBackConfig? createEditPostCallBackConfig;
   final CreateEditPostUIConfig? createEditPostUIConfig;
   final bool autoMoveToNextPost;
+  final bool enablePaidPost;
+  final String paidPostCurrency;
+  final List<int> paidPostAmountSuggestions;
 
   CreateEditPostConfig copyWith({
     CreateEditPostCallBackConfig? createEditPostCallBackConfig,
     CreateEditPostUIConfig? createEditPostUIConfig,
     bool? autoMoveToNextPost,
+    bool? enablePaidPost,
+    String? paidPostCurrency,
+    List<int>? paidPostAmountSuggestions,
   }) =>
       CreateEditPostConfig(
         createEditPostCallBackConfig:
@@ -25,6 +34,10 @@ class CreateEditPostConfig {
         createEditPostUIConfig:
             createEditPostUIConfig ?? this.createEditPostUIConfig,
         autoMoveToNextPost: autoMoveToNextPost ?? this.autoMoveToNextPost,
+        enablePaidPost: enablePaidPost ?? this.enablePaidPost,
+        paidPostCurrency: paidPostCurrency ?? this.paidPostCurrency,
+        paidPostAmountSuggestions:
+            paidPostAmountSuggestions ?? this.paidPostAmountSuggestions,
       );
 }
 

--- a/lib/domain/models/post_config.dart
+++ b/lib/domain/models/post_config.dart
@@ -556,6 +556,7 @@ class PostCallBackConfig {
     this.onTagProductClick,
     this.onPostChanged,
     this.onViewCountClicked,
+    this.onPaidPostUnlock,
   });
 
   final Function(TimeLineData postData, bool isSaved)? onSaveChanged;
@@ -576,6 +577,9 @@ class PostCallBackConfig {
   final Function(TimeLineData postData, int index)? onPostChanged;
   final Future<void> Function(TimeLineData postData)? onViewCountClicked;
 
+  /// Host app handles purchase / coin flow when the user taps unlock on a paid post.
+  final Future<void> Function(TimeLineData postData)? onPaidPostUnlock;
+
   PostCallBackConfig copyWith({
     Function(TimeLineData postData, bool isSaved)? onSaveChanged,
     Function(TimeLineData postData, bool isLiked)? onLikeChanged,
@@ -590,6 +594,7 @@ class PostCallBackConfig {
     Future<void> Function(TimeLineData postData)? onTagProductClick,
     Function(TimeLineData postData, int index)? onPostChanged,
     Future<void> Function(TimeLineData postData)? onViewCountClicked,
+    Future<void> Function(TimeLineData postData)? onPaidPostUnlock,
   }) =>
       PostCallBackConfig(
         onSaveChanged: onSaveChanged ?? this.onSaveChanged,
@@ -603,5 +608,6 @@ class PostCallBackConfig {
         onTagProductClick: onTagProductClick ?? this.onTagProductClick,
         onPostChanged: onPostChanged ?? this.onPostChanged,
         onViewCountClicked: onViewCountClicked ?? this.onViewCountClicked,
+        onPaidPostUnlock: onPaidPostUnlock ?? this.onPaidPostUnlock,
       );
 }

--- a/lib/domain/models/reels_data.dart
+++ b/lib/domain/models/reels_data.dart
@@ -34,6 +34,11 @@ class ReelsData {
     this.createOn,
     this.watchDuration,
     this.interests,
+    this.isLocked,
+    this.lockReason,
+    this.isPaid,
+    this.priceAmount,
+    this.priceCurrency,
   });
 
   final dynamic postData;
@@ -71,6 +76,13 @@ class ReelsData {
   final num? watchDuration;
   final List<String>? interests;
 
+  /// Timeline / API: `is_locked`, `lock_reason`, paid pricing in `settings`.
+  final bool? isLocked;
+  final String? lockReason;
+  final bool? isPaid;
+  final Object? priceAmount;
+  final String? priceCurrency;
+
   ReelsData copyWith({
     bool? isFollow,
     bool? isLiked,
@@ -78,6 +90,11 @@ class ReelsData {
     int? likesCount,
     int? viewCount,
     int? commentCount,
+    bool? isLocked,
+    String? lockReason,
+    bool? isPaid,
+    Object? priceAmount,
+    String? priceCurrency,
   }) =>
       ReelsData(
         postData: postData,
@@ -109,6 +126,11 @@ class ReelsData {
         viewCount: viewCount ?? this.viewCount,
         commentCount: commentCount ?? this.commentCount,
         interests: interests,
+        isLocked: isLocked ?? this.isLocked,
+        lockReason: lockReason ?? this.lockReason,
+        isPaid: isPaid ?? this.isPaid,
+        priceAmount: priceAmount ?? this.priceAmount,
+        priceCurrency: priceCurrency ?? this.priceCurrency,
       );
 }
 

--- a/lib/domain/models/request/create_post_request.dart
+++ b/lib/domain/models/request/create_post_request.dart
@@ -85,19 +85,30 @@ class CreatePostRequest {
 }
 
 class PostSettingModel {
-  factory PostSettingModel.fromJson(Map<String, dynamic> json) =>
-      PostSettingModel(
-        advanceInterval: json['advance_interval'] as num? ?? 0,
-        ageRestriction: json['age_restriction'] as bool? ?? false,
-        autoAdvance: json['auto_advance'] as bool? ?? false,
-        commentsEnabled: json['comments_enabled'] as bool? ?? false,
-        duetEnabled: json['duet_enabled'] as bool? ?? false,
-        saveEnabled: json['save_enabled'] as bool? ?? false,
-        stitchEnabled: json['stitch_enabled'] as bool? ?? false,
-        isPaid: json['is_paid'] as bool?,
-        priceAmount: json['price_amount'],
-        priceCurrency: json['price_currency'] as String?,
-      );
+  factory PostSettingModel.fromJson(Map<String, dynamic> json) {
+    final isPaid = _readBool(json['is_paid'], key: 'is_paid');
+    final priceAmount =
+        _readPriceAmount(json['price_amount'], key: 'price_amount');
+    final normalizedIsPaid =
+        (isPaid == true && priceAmount == null) ? false : isPaid;
+
+    return PostSettingModel(
+      advanceInterval:
+          _readNum(json['advance_interval'], key: 'advance_interval') ?? 0,
+      ageRestriction:
+          _readBool(json['age_restriction'], key: 'age_restriction') ?? false,
+      autoAdvance: _readBool(json['auto_advance'], key: 'auto_advance') ?? false,
+      commentsEnabled:
+          _readBool(json['comments_enabled'], key: 'comments_enabled') ?? false,
+      duetEnabled: _readBool(json['duet_enabled'], key: 'duet_enabled') ?? false,
+      saveEnabled: _readBool(json['save_enabled'], key: 'save_enabled') ?? false,
+      stitchEnabled:
+          _readBool(json['stitch_enabled'], key: 'stitch_enabled') ?? false,
+      isPaid: normalizedIsPaid,
+      priceAmount: priceAmount,
+      priceCurrency: json['price_currency'] as String?,
+    );
+  }
 
   PostSettingModel({
     this.advanceInterval,
@@ -122,6 +133,34 @@ class PostSettingModel {
   final bool? isPaid;
   final Object? priceAmount;
   final String? priceCurrency;
+
+  static bool? _readBool(dynamic value, {required String key}) {
+    if (value == null) return null;
+    if (value is bool) return value;
+    if (value is num) return value != 0;
+    if (value is String) {
+      final normalized = value.trim().toLowerCase();
+      if (normalized == 'true' || normalized == '1') return true;
+      if (normalized == 'false' || normalized == '0') return false;
+    }
+    return null;
+  }
+
+  static num? _readNum(dynamic value, {required String key}) {
+    if (value == null) return null;
+    if (value is num) return value;
+    if (value is String) {
+      final parsed = num.tryParse(value);
+      if (parsed != null) return parsed;
+    }
+    return null;
+  }
+
+  static Object? _readPriceAmount(dynamic value, {required String key}) {
+    if (value == null) return null;
+    if (value is num || value is String) return value;
+    return null;
+  }
 
   Map<String, dynamic> toJson() => {
         'advance_interval': advanceInterval ?? 0,

--- a/lib/domain/models/request/create_post_request.dart
+++ b/lib/domain/models/request/create_post_request.dart
@@ -162,16 +162,24 @@ class PostSettingModel {
     return null;
   }
 
-  Map<String, dynamic> toJson() => {
-        'advance_interval': advanceInterval ?? 0,
-        'age_restriction': ageRestriction ?? false,
-        'auto_advance': autoAdvance ?? false,
-        'comments_enabled': commentsEnabled ?? false,
-        'duet_enabled': duetEnabled ?? false,
-        'save_enabled': saveEnabled ?? false,
-        'stitch_enabled': stitchEnabled ?? false,
-        if (isPaid != null) 'is_paid': isPaid,
-        if (priceAmount != null) 'price_amount': priceAmount,
-        if (priceCurrency != null) 'price_currency': priceCurrency,
-      };
+  Map<String, dynamic> toJson() {
+    final payload = <String, dynamic>{
+      'advance_interval': advanceInterval ?? 0,
+      'age_restriction': ageRestriction ?? false,
+      'auto_advance': autoAdvance ?? false,
+      'comments_enabled': commentsEnabled ?? false,
+      'duet_enabled': duetEnabled ?? false,
+      'save_enabled': saveEnabled ?? false,
+      'stitch_enabled': stitchEnabled ?? false,
+    };
+    final shouldSendPaidFields = isPaid == true &&
+        priceAmount != null &&
+        (priceCurrency?.trim().isNotEmpty ?? false);
+    if (shouldSendPaidFields) {
+      payload['is_paid'] = true;
+      payload['price_amount'] = priceAmount;
+      payload['price_currency'] = priceCurrency;
+    }
+    return payload;
+  }
 }

--- a/lib/domain/models/request/create_post_request.dart
+++ b/lib/domain/models/request/create_post_request.dart
@@ -94,6 +94,9 @@ class PostSettingModel {
         duetEnabled: json['duet_enabled'] as bool? ?? false,
         saveEnabled: json['save_enabled'] as bool? ?? false,
         stitchEnabled: json['stitch_enabled'] as bool? ?? false,
+        isPaid: json['is_paid'] as bool?,
+        priceAmount: json['price_amount'],
+        priceCurrency: json['price_currency'] as String?,
       );
 
   PostSettingModel({
@@ -104,6 +107,9 @@ class PostSettingModel {
     this.duetEnabled,
     this.saveEnabled,
     this.stitchEnabled,
+    this.isPaid,
+    this.priceAmount,
+    this.priceCurrency,
   });
 
   final num? advanceInterval;
@@ -113,6 +119,9 @@ class PostSettingModel {
   final bool? duetEnabled;
   final bool? saveEnabled;
   final bool? stitchEnabled;
+  final bool? isPaid;
+  final Object? priceAmount;
+  final String? priceCurrency;
 
   Map<String, dynamic> toJson() => {
         'advance_interval': advanceInterval ?? 0,
@@ -122,5 +131,8 @@ class PostSettingModel {
         'duet_enabled': duetEnabled ?? false,
         'save_enabled': saveEnabled ?? false,
         'stitch_enabled': stitchEnabled ?? false,
+        if (isPaid != null) 'is_paid': isPaid,
+        if (priceAmount != null) 'price_amount': priceAmount,
+        if (priceCurrency != null) 'price_currency': priceCurrency,
       };
 }

--- a/lib/domain/models/response/timeline_response.dart
+++ b/lib/domain/models/response/timeline_response.dart
@@ -483,19 +483,31 @@ class Settings {
     this.audioSettings,
   });
 
-  factory Settings.fromMap(Map<String, dynamic> json) => Settings(
-        commentsEnabled: json['comments_enabled'] as bool? ?? false,
-        duetEnabled: json['duet_enabled'] as bool? ?? false,
-        stitchEnabled: json['stitch_enabled'] as bool? ?? false,
-        saveEnabled: json['save_enabled'] as bool? ?? false,
-        isPaid: json['is_paid'] as bool?,
-        priceAmount: json['price_amount'],
-        priceCurrency: json['price_currency'] as String?,
-        ageRestriction: json['age_restriction'] as bool? ?? false,
-        autoAdvance: json['auto_advance'] as bool? ?? false,
-        advanceInterval: json['advance_interval'] as num? ?? 0,
-        audioSettings: json['audio_settings'],
-      );
+  factory Settings.fromMap(Map<String, dynamic> json) {
+    final isPaid = _readBool(json['is_paid'], key: 'is_paid');
+    final priceAmount =
+        _readPriceAmount(json['price_amount'], key: 'price_amount');
+    final normalizedIsPaid =
+        (isPaid == true && priceAmount == null) ? false : isPaid;
+
+    return Settings(
+      commentsEnabled:
+          _readBool(json['comments_enabled'], key: 'comments_enabled') ?? false,
+      duetEnabled: _readBool(json['duet_enabled'], key: 'duet_enabled') ?? false,
+      stitchEnabled:
+          _readBool(json['stitch_enabled'], key: 'stitch_enabled') ?? false,
+      saveEnabled: _readBool(json['save_enabled'], key: 'save_enabled') ?? false,
+      isPaid: normalizedIsPaid,
+      priceAmount: priceAmount,
+      priceCurrency: json['price_currency'] as String?,
+      ageRestriction:
+          _readBool(json['age_restriction'], key: 'age_restriction') ?? false,
+      autoAdvance: _readBool(json['auto_advance'], key: 'auto_advance') ?? false,
+      advanceInterval:
+          _readNum(json['advance_interval'], key: 'advance_interval') ?? 0,
+      audioSettings: json['audio_settings'],
+    );
+  }
   bool? commentsEnabled;
   bool? duetEnabled;
   bool? stitchEnabled;
@@ -507,6 +519,34 @@ class Settings {
   bool? autoAdvance;
   num? advanceInterval;
   dynamic audioSettings;
+
+  static bool? _readBool(dynamic value, {required String key}) {
+    if (value == null) return null;
+    if (value is bool) return value;
+    if (value is num) return value != 0;
+    if (value is String) {
+      final normalized = value.trim().toLowerCase();
+      if (normalized == 'true' || normalized == '1') return true;
+      if (normalized == 'false' || normalized == '0') return false;
+    }
+    return null;
+  }
+
+  static num? _readNum(dynamic value, {required String key}) {
+    if (value == null) return null;
+    if (value is num) return value;
+    if (value is String) {
+      final parsed = num.tryParse(value);
+      if (parsed != null) return parsed;
+    }
+    return null;
+  }
+
+  static Object? _readPriceAmount(dynamic value, {required String key}) {
+    if (value == null) return null;
+    if (value is num || value is String) return value;
+    return null;
+  }
 
   Map<String, dynamic> toMap() => {
         'comments_enabled': commentsEnabled,

--- a/lib/domain/models/response/timeline_response.dart
+++ b/lib/domain/models/response/timeline_response.dart
@@ -174,6 +174,8 @@ class TimeLineData {
     this.interests,
     this.status,
     this.scheduledAt,
+    this.isLocked,
+    this.lockReason,
   });
 
   factory TimeLineData.fromMap(Map<String, dynamic> json) => TimeLineData(
@@ -220,6 +222,8 @@ class TimeLineData {
             : List<String>.from(json['interests'] as List)
                 .map((item) => item)
                 .toList(),
+        isLocked: json['is_locked'] as bool?,
+        lockReason: json['lock_reason'] as String?,
       );
   dynamic textFormatting;
   String? publishedAt;
@@ -243,6 +247,8 @@ class TimeLineData {
   bool? isFollowing;
   String? status;
   List<String>? interests;
+  bool? isLocked;
+  String? lockReason;
 
   Map<String, dynamic> toMap() => {
         'text_formatting': textFormatting,
@@ -273,6 +279,8 @@ class TimeLineData {
             ? []
             : List<dynamic>.from(interests!.map((x) => x)),
         'scheduled_at': scheduledAt,
+        'is_locked': isLocked,
+        'lock_reason': lockReason,
       };
 }
 
@@ -466,6 +474,9 @@ class Settings {
     this.duetEnabled,
     this.stitchEnabled,
     this.saveEnabled,
+    this.isPaid,
+    this.priceAmount,
+    this.priceCurrency,
     this.ageRestriction,
     this.autoAdvance,
     this.advanceInterval,
@@ -477,6 +488,9 @@ class Settings {
         duetEnabled: json['duet_enabled'] as bool? ?? false,
         stitchEnabled: json['stitch_enabled'] as bool? ?? false,
         saveEnabled: json['save_enabled'] as bool? ?? false,
+        isPaid: json['is_paid'] as bool?,
+        priceAmount: json['price_amount'],
+        priceCurrency: json['price_currency'] as String?,
         ageRestriction: json['age_restriction'] as bool? ?? false,
         autoAdvance: json['auto_advance'] as bool? ?? false,
         advanceInterval: json['advance_interval'] as num? ?? 0,
@@ -486,6 +500,9 @@ class Settings {
   bool? duetEnabled;
   bool? stitchEnabled;
   bool? saveEnabled;
+  bool? isPaid;
+  Object? priceAmount;
+  String? priceCurrency;
   bool? ageRestriction;
   bool? autoAdvance;
   num? advanceInterval;
@@ -496,6 +513,9 @@ class Settings {
         'duet_enabled': duetEnabled,
         'stitch_enabled': stitchEnabled,
         'save_enabled': saveEnabled,
+        if (isPaid != null) 'is_paid': isPaid,
+        if (priceAmount != null) 'price_amount': priceAmount,
+        if (priceCurrency != null) 'price_currency': priceCurrency,
         'age_restriction': ageRestriction,
         'auto_advance': autoAdvance,
         'advance_interval': advanceInterval,
@@ -952,10 +972,39 @@ class PlaceData {
       };
 }
 
+List<MediaMetaData> reelMediaMetaDataFromTimeline(TimeLineData postData) {
+  if (postData.media.isListEmptyOrNull == false) {
+    return postData.media!.map(_getMediaMetaData).toList();
+  }
+  final previews = postData.previews;
+  if (previews.isListEmptyOrNull == false) {
+    final sorted = List<PreviewMedia>.from(previews!)
+      ..sort((a, b) => (a.position ?? 0).compareTo(b.position ?? 0));
+    return sorted.map((p) {
+      final isImage = (p.mediaType ?? '').toLowerCase() == 'image';
+      final url = p.url ?? '';
+      return MediaMetaData(
+        mediaUrl: url,
+        thumbnailUrl: url,
+        mediaType: isImage ? 0 : 1,
+        durationSeconds: isImage
+            ? AppConstants.defaultImagePostDurationSeconds
+            : AppConstants.defaultImagePostDurationSeconds,
+      );
+    }).toList();
+  }
+  return [];
+}
+
 ReelsData getReelData(TimeLineData postData, {String? loggedInUserId}) =>
     ReelsData(
       postData: postData,
       createOn: postData.publishedAt,
+      isLocked: postData.isLocked,
+      lockReason: postData.lockReason,
+      isPaid: postData.settings?.isPaid,
+      priceAmount: postData.settings?.priceAmount,
+      priceCurrency: postData.settings?.priceCurrency,
       postSetting: PostSetting(
         isProfilePicVisible: true,
         isCreatePostButtonVisible: false,
@@ -981,7 +1030,7 @@ ReelsData getReelData(TimeLineData postData, {String? loggedInUserId}) =>
           : null,
       postId: postData.id,
       tags: postData.tags,
-      mediaMetaDataList: postData.media?.map(_getMediaMetaData).toList() ?? [],
+      mediaMetaDataList: reelMediaMetaDataFromTimeline(postData),
       userId: postData.user?.id ?? '',
       userName: postData.user?.username ?? '',
       profilePhoto: postData.user?.avatarUrl ?? '',

--- a/lib/presentation/bloc/create_post/create_post_bloc.dart
+++ b/lib/presentation/bloc/create_post/create_post_bloc.dart
@@ -971,6 +971,21 @@ class CreatePostBloc extends Bloc<CreatePostEvent, CreatePostState> {
     _postAttributeClass.taggedPlaces = locationTagDataList;
     _postAttributeClass.allowSave = _postData?.settings?.saveEnabled;
     _postAttributeClass.allowComment = _postData?.settings?.commentsEnabled;
+    final postSettings = _postData?.settings;
+    if (postSettings != null) {
+      _createPostRequest.settings = PostSettingModel(
+        advanceInterval: postSettings.advanceInterval,
+        ageRestriction: postSettings.ageRestriction,
+        autoAdvance: postSettings.autoAdvance,
+        commentsEnabled: postSettings.commentsEnabled,
+        duetEnabled: postSettings.duetEnabled,
+        saveEnabled: postSettings.saveEnabled,
+        stitchEnabled: postSettings.stitchEnabled,
+        isPaid: postSettings.isPaid,
+        priceAmount: postSettings.priceAmount,
+        priceCurrency: postSettings.priceCurrency,
+      );
+    }
   }
 
   bool checkForChangesInLinkedProducts(List<ProductDataModel> linkedProducts) {

--- a/lib/presentation/screens/create_post/post_attribute_view.dart
+++ b/lib/presentation/screens/create_post/post_attribute_view.dart
@@ -3,6 +3,7 @@ import 'dart:io';
 
 import 'package:flutter/foundation.dart';
 import 'package:flutter/material.dart';
+import 'package:flutter/services.dart';
 import 'package:flutter_bloc/flutter_bloc.dart';
 import 'package:flutter_screenutil/flutter_screenutil.dart';
 import 'package:fluttertagger/fluttertagger.dart';
@@ -42,6 +43,7 @@ class _PostAttributeViewState extends State<PostAttributeView>
   final GlobalKey _captionInputKey = GlobalKey();
   bool isKeyboardVisible = false;
   final FocusNode _descriptionFocusNode = FocusNode();
+  final TextEditingController _paidAmountController = TextEditingController();
 
   // State variables for tracking changes
   bool _isPostButtonEnabled = true;
@@ -78,6 +80,8 @@ class _PostAttributeViewState extends State<PostAttributeView>
   bool get _useBackgroundPostUi =>
       IsrVideoReelConfig.createEditPostConfig.createEditPostCallBackConfig?.onBackgroundPostOperation !=
       null;
+  bool get _isPaidPostEnabled =>
+      IsrVideoReelConfig.createEditPostConfig.enablePaidPost;
 
   @override
   void initState() {
@@ -141,6 +145,15 @@ class _PostAttributeViewState extends State<PostAttributeView>
     // Set default values for new posts
     _postAttributeClass?.allowComment ??= true;
     _postAttributeClass?.allowSave ??= true;
+    _postAttributeClass?.createPostRequest?.settings ??= PostSettingModel(
+      commentsEnabled: _postAttributeClass?.allowComment ?? true,
+      saveEnabled: _postAttributeClass?.allowSave ?? true,
+      isPaid: false,
+    );
+    final existingAmount =
+        _postAttributeClass?.createPostRequest?.settings?.priceAmount;
+    _paidAmountController.text =
+        existingAmount == null ? '' : existingAmount.toString();
 
     // Store original values for change detection in edit mode
     _originalPostAttributeClass = _copyPostAttributeClass(_postAttributeClass);
@@ -226,6 +239,7 @@ class _PostAttributeViewState extends State<PostAttributeView>
   void dispose() {
     WidgetsBinding.instance.removeObserver(this);
     _descriptionController.dispose();
+    _paidAmountController.dispose();
     _scrollController.dispose();
     // Dispose all video controllers
     for (final controller in _videoControllers.values) {
@@ -269,7 +283,21 @@ class _PostAttributeViewState extends State<PostAttributeView>
       final copyRequest = CreatePostRequest();
       copyRequest.caption = originalRequest.caption;
       copyRequest.tags = originalRequest.tags;
-      copyRequest.settings = originalRequest.settings;
+      final originalSettings = originalRequest.settings;
+      if (originalSettings != null) {
+        copyRequest.settings = PostSettingModel(
+          advanceInterval: originalSettings.advanceInterval,
+          ageRestriction: originalSettings.ageRestriction,
+          autoAdvance: originalSettings.autoAdvance,
+          commentsEnabled: originalSettings.commentsEnabled,
+          duetEnabled: originalSettings.duetEnabled,
+          saveEnabled: originalSettings.saveEnabled,
+          stitchEnabled: originalSettings.stitchEnabled,
+          isPaid: originalSettings.isPaid,
+          priceAmount: originalSettings.priceAmount,
+          priceCurrency: originalSettings.priceCurrency,
+        );
+      }
       copy.createPostRequest = copyRequest;
     }
 
@@ -286,7 +314,8 @@ class _PostAttributeViewState extends State<PostAttributeView>
     // Simple and clear logic:
     // - If it's a new post: ALWAYS enabled
     // - If it's edit mode: Only enabled if there are changes
-    final shouldEnable = _isEditMode ? _hasChanges() : true;
+    final shouldEnable =
+        (_isEditMode ? _hasChanges() : true) && _isPaidAmountValid();
 
     debugPrint('shouldEnable result: $shouldEnable');
     debugPrint('Current _isPostButtonEnabled: $_isPostButtonEnabled');
@@ -300,6 +329,14 @@ class _PostAttributeViewState extends State<PostAttributeView>
       debugPrint('⚪ Button state unchanged');
     }
     debugPrint('=== END _updatePostButtonState ===');
+  }
+
+  bool _isPaidAmountValid() {
+    if (!_isPaidPostEnabled) return true;
+    final settings = _postAttributeClass?.createPostRequest?.settings;
+    if (settings?.isPaid != true) return true;
+    final amount = int.tryParse(_paidAmountController.text.trim());
+    return (amount ?? 0) > 0;
   }
 
   /// Check if there are any changes compared to original data
@@ -349,6 +386,15 @@ class _PostAttributeViewState extends State<PostAttributeView>
     if (original.allowComment != current.allowComment ||
         original.allowSave != current.allowSave) {
       debugPrint('Changes detected in settings');
+      return true;
+    }
+    final originalSettings = original.createPostRequest?.settings;
+    final currentSettings = current.createPostRequest?.settings;
+    if (originalSettings?.isPaid != currentSettings?.isPaid ||
+        originalSettings?.priceAmount?.toString() !=
+            currentSettings?.priceAmount?.toString() ||
+        originalSettings?.priceCurrency != currentSettings?.priceCurrency) {
+      debugPrint('Changes detected in paid post settings');
       return true;
     }
 
@@ -794,6 +840,8 @@ class _PostAttributeViewState extends State<PostAttributeView>
                         // Add Location
                         _buildLocationTile(),
 
+                        if (_isPaidPostEnabled) _buildPaidPostSection(),
+
                         // Allow Comments
                         _buildSwitchTile(
                           icon: AssetConstants.icAllowComment,
@@ -1141,6 +1189,144 @@ class _PostAttributeViewState extends State<PostAttributeView>
                 });
               });
             },
+    );
+  }
+
+  Widget _buildPaidPostSection() {
+    final settings = _postAttributeClass?.createPostRequest?.settings;
+    final isPaid = settings?.isPaid == true;
+    final amountSuggestions =
+        IsrVideoReelConfig.createEditPostConfig.paidPostAmountSuggestions;
+    return Column(
+      crossAxisAlignment: CrossAxisAlignment.start,
+      children: [
+        _buildSwitchTile(
+          icon: AssetConstants.icAllowComment,
+          title: 'Paid Post',
+          value: isPaid,
+          onChanged: (value) {
+            setState(() {
+              _postAttributeClass?.createPostRequest?.settings = PostSettingModel(
+                commentsEnabled:
+                    settings?.commentsEnabled ?? _postAttributeClass?.allowComment ?? true,
+                saveEnabled: settings?.saveEnabled ?? _postAttributeClass?.allowSave ?? true,
+                isPaid: value,
+                priceAmount: value
+                    ? (_paidAmountController.text.trim().isEmpty
+                        ? null
+                        : _paidAmountController.text.trim())
+                    : null,
+                priceCurrency: value
+                    ? IsrVideoReelConfig.createEditPostConfig.paidPostCurrency
+                    : null,
+              );
+              if (!value) {
+                _paidAmountController.clear();
+              }
+            });
+            _updatePostButtonState();
+          },
+        ),
+        if (isPaid)
+          Padding(
+            padding: IsrDimens.edgeInsetsSymmetric(
+              horizontal: 20.responsiveDimension,
+              vertical: 8.responsiveDimension,
+            ),
+            child: Column(
+              crossAxisAlignment: CrossAxisAlignment.start,
+              children: [
+                Text(
+                  'Amount',
+                  style: IsrStyles.primaryText14.copyWith(fontWeight: FontWeight.w600),
+                ),
+                8.verticalSpace,
+                TextFormField(
+                  controller: _paidAmountController,
+                  keyboardType: TextInputType.number,
+                  inputFormatters: [FilteringTextInputFormatter.digitsOnly],
+                  onChanged: (value) {
+                    final oldSettings =
+                        _postAttributeClass?.createPostRequest?.settings;
+                    _postAttributeClass?.createPostRequest?.settings = PostSettingModel(
+                      commentsEnabled: oldSettings?.commentsEnabled ??
+                          _postAttributeClass?.allowComment ??
+                          true,
+                      saveEnabled:
+                          oldSettings?.saveEnabled ?? _postAttributeClass?.allowSave ?? true,
+                      isPaid: true,
+                      priceAmount: value.trim().isEmpty ? null : value.trim(),
+                      priceCurrency:
+                          IsrVideoReelConfig.createEditPostConfig.paidPostCurrency,
+                    );
+                    _updatePostButtonState();
+                  },
+                  decoration: InputDecoration(
+                    hintText: 'Enter amount',
+                    border: OutlineInputBorder(
+                      borderRadius: BorderRadius.circular(8),
+                    ),
+                    contentPadding: IsrDimens.edgeInsetsSymmetric(
+                      horizontal: 12.responsiveDimension,
+                      vertical: 10.responsiveDimension,
+                    ),
+                  ),
+                ),
+                10.verticalSpace,
+                Text(
+                  'Choose your coin',
+                  style: IsrStyles.primaryText14.copyWith(fontWeight: FontWeight.w600),
+                ),
+                8.verticalSpace,
+                Wrap(
+                  spacing: 8.responsiveDimension,
+                  runSpacing: 8.responsiveDimension,
+                  children: amountSuggestions
+                      .map(
+                        (amount) => InkWell(
+                          onTap: () {
+                            _paidAmountController.text = amount.toString();
+                            _postAttributeClass?.createPostRequest?.settings =
+                                PostSettingModel(
+                              commentsEnabled: settings?.commentsEnabled ??
+                                  _postAttributeClass?.allowComment ??
+                                  true,
+                              saveEnabled: settings?.saveEnabled ??
+                                  _postAttributeClass?.allowSave ??
+                                  true,
+                              isPaid: true,
+                              priceAmount: amount.toString(),
+                              priceCurrency: IsrVideoReelConfig
+                                  .createEditPostConfig.paidPostCurrency,
+                            );
+                            setState(() {});
+                            _updatePostButtonState();
+                          },
+                          child: Container(
+                            padding: IsrDimens.edgeInsetsSymmetric(
+                              horizontal: 16.responsiveDimension,
+                              vertical: 10.responsiveDimension,
+                            ),
+                            decoration: BoxDecoration(
+                              color: IsrColors.appColor.withValues(alpha: 0.08),
+                              borderRadius: BorderRadius.circular(8),
+                              border:
+                                  Border.all(color: IsrColors.appColor.withValues(alpha: 0.25)),
+                            ),
+                            child: Text(
+                              amount.toString(),
+                              style:
+                                  IsrStyles.primaryText14.copyWith(fontWeight: FontWeight.w600),
+                            ),
+                          ),
+                        ),
+                      )
+                      .toList(),
+                ),
+              ],
+            ),
+          ),
+      ],
     );
   }
 
@@ -1634,6 +1820,18 @@ class _PostAttributeViewState extends State<PostAttributeView>
       final settings = PostSettingModel(
         saveEnabled: _postAttributeClass?.allowSave,
         commentsEnabled: _postAttributeClass?.allowComment,
+        isPaid: _isPaidPostEnabled
+            ? (_postAttributeClass?.createPostRequest?.settings?.isPaid ?? false)
+            : null,
+        priceAmount: _isPaidPostEnabled &&
+                (_postAttributeClass?.createPostRequest?.settings?.isPaid == true) &&
+                _paidAmountController.text.trim().isNotEmpty
+            ? _paidAmountController.text.trim()
+            : null,
+        priceCurrency: _isPaidPostEnabled &&
+                (_postAttributeClass?.createPostRequest?.settings?.isPaid == true)
+            ? IsrVideoReelConfig.createEditPostConfig.paidPostCurrency
+            : null,
       );
       createPostRequest.settings = settings;
 

--- a/lib/presentation/screens/create_post/post_attribute_view.dart
+++ b/lib/presentation/screens/create_post/post_attribute_view.dart
@@ -335,8 +335,16 @@ class _PostAttributeViewState extends State<PostAttributeView>
     if (!_isPaidPostEnabled) return true;
     final settings = _postAttributeClass?.createPostRequest?.settings;
     if (settings?.isPaid != true) return true;
-    final amount = int.tryParse(_paidAmountController.text.trim());
+    final amount = num.tryParse(_paidAmountController.text.trim());
     return (amount ?? 0) > 0;
+  }
+
+  String? _getPaidAmountErrorText() {
+    if (!_isPaidPostEnabled) return null;
+    final settings = _postAttributeClass?.createPostRequest?.settings;
+    if (settings?.isPaid != true) return null;
+    if (_paidAmountController.text.trim().isEmpty) return null;
+    return _isPaidAmountValid() ? null : 'Amount must be greater than 0';
   }
 
   /// Check if there are any changes compared to original data
@@ -1206,16 +1214,14 @@ class _PostAttributeViewState extends State<PostAttributeView>
           value: isPaid,
           onChanged: (value) {
             setState(() {
+              final currentAmount =
+                  num.tryParse(_paidAmountController.text.trim());
               _postAttributeClass?.createPostRequest?.settings = PostSettingModel(
                 commentsEnabled:
                     settings?.commentsEnabled ?? _postAttributeClass?.allowComment ?? true,
                 saveEnabled: settings?.saveEnabled ?? _postAttributeClass?.allowSave ?? true,
                 isPaid: value,
-                priceAmount: value
-                    ? (_paidAmountController.text.trim().isEmpty
-                        ? null
-                        : _paidAmountController.text.trim())
-                    : null,
+                priceAmount: value ? currentAmount : null,
                 priceCurrency: value
                     ? IsrVideoReelConfig.createEditPostConfig.paidPostCurrency
                     : null,
@@ -1248,6 +1254,7 @@ class _PostAttributeViewState extends State<PostAttributeView>
                   onChanged: (value) {
                     final oldSettings =
                         _postAttributeClass?.createPostRequest?.settings;
+                    final parsedAmount = num.tryParse(value.trim());
                     _postAttributeClass?.createPostRequest?.settings = PostSettingModel(
                       commentsEnabled: oldSettings?.commentsEnabled ??
                           _postAttributeClass?.allowComment ??
@@ -1255,14 +1262,16 @@ class _PostAttributeViewState extends State<PostAttributeView>
                       saveEnabled:
                           oldSettings?.saveEnabled ?? _postAttributeClass?.allowSave ?? true,
                       isPaid: true,
-                      priceAmount: value.trim().isEmpty ? null : value.trim(),
+                      priceAmount: parsedAmount,
                       priceCurrency:
                           IsrVideoReelConfig.createEditPostConfig.paidPostCurrency,
                     );
+                    setState(() {});
                     _updatePostButtonState();
                   },
                   decoration: InputDecoration(
                     hintText: 'Enter amount',
+                    errorText: _getPaidAmountErrorText(),
                     border: OutlineInputBorder(
                       borderRadius: BorderRadius.circular(8),
                     ),
@@ -1295,7 +1304,7 @@ class _PostAttributeViewState extends State<PostAttributeView>
                                   _postAttributeClass?.allowSave ??
                                   true,
                               isPaid: true,
-                              priceAmount: amount.toString(),
+                              priceAmount: amount,
                               priceCurrency: IsrVideoReelConfig
                                   .createEditPostConfig.paidPostCurrency,
                             );
@@ -1789,6 +1798,12 @@ class _PostAttributeViewState extends State<PostAttributeView>
   }
 
   void _createPost() {
+    if (!_isPaidAmountValid()) {
+      Utility.showAppDialog(
+        message: 'Please enter a paid amount greater than 0',
+      );
+      return;
+    }
     _setPostRequest();
     context.getOrCreateBloc<CreatePostBloc>().add(PostCreateEvent(
       createPostRequest:
@@ -1826,7 +1841,7 @@ class _PostAttributeViewState extends State<PostAttributeView>
         priceAmount: _isPaidPostEnabled &&
                 (_postAttributeClass?.createPostRequest?.settings?.isPaid == true) &&
                 _paidAmountController.text.trim().isNotEmpty
-            ? _paidAmountController.text.trim()
+            ? num.tryParse(_paidAmountController.text.trim())
             : null,
         priceCurrency: _isPaidPostEnabled &&
                 (_postAttributeClass?.createPostRequest?.settings?.isPaid == true)

--- a/lib/presentation/screens/posts/ism_reels_video_player_view.dart
+++ b/lib/presentation/screens/posts/ism_reels_video_player_view.dart
@@ -276,8 +276,9 @@ class _IsmReelsVideoPlayerViewState extends State<IsmReelsVideoPlayerView>
     return isPaidLocked;
   }
 
-  TimeLineData? get _timelinePost =>
-      _reelData.postData is TimeLineData ? _reelData.postData as TimeLineData : null;
+  TimeLineData? get _timelinePost => _reelData.postData is TimeLineData
+      ? _reelData.postData as TimeLineData
+      : null;
 
   static bool _looksLikeStreamingOrVideoUrl(String url) {
     final u = url.trim().toLowerCase();
@@ -309,8 +310,7 @@ class _IsmReelsVideoPlayerViewState extends State<IsmReelsVideoPlayerView>
     }
 
     if (_reelData.mediaMetaDataList.isNotEmpty) {
-      final meta =
-          _reelData.mediaMetaDataList[_currentPageNotifier.value];
+      final meta = _reelData.mediaMetaDataList[_currentPageNotifier.value];
       if (meta.mediaType == kVideoType) {
         final thumb = usableStill(meta.thumbnailUrl);
         if (thumb != null) return thumb;
@@ -384,11 +384,6 @@ class _IsmReelsVideoPlayerViewState extends State<IsmReelsVideoPlayerView>
 
     // Initialize PageController for carousel
     _pageController = PreloadPageController(initialPage: 0);
-
-    if (_reelData.mediaMetaDataList.isEmpty) {
-      unawaited(_fetchFloatingCommentsIfNeeded());
-      return;
-    }
 
     if (!_shouldShowPaidLockOverlay) {
       _preloadNextVideos();
@@ -624,89 +619,89 @@ class _IsmReelsVideoPlayerViewState extends State<IsmReelsVideoPlayerView>
     const blurSigma = 28.0;
     final primary = Theme.of(context).colorScheme.primary;
 
-    Widget chrome({Widget? blurredChild}) {
-      return Stack(
-        fit: StackFit.expand,
-        children: [
-          if (blurredChild != null)
-            ImageFiltered(
-              imageFilter:
-                  ImageFilter.blur(sigmaX: blurSigma, sigmaY: blurSigma),
-              child: blurredChild,
-            )
-          else
-            ColoredBox(color: Colors.grey.shade900),
-          Container(color: Colors.black.withValues(alpha: 0.42)),
-          Center(
-            child: Padding(
-              padding: IsrDimens.edgeInsetsSymmetric(horizontal: IsrDimens.twentyEight),
-              child: Column(
-                mainAxisSize: MainAxisSize.min,
-                children: [
-                  Container(
-                    padding: IsrDimens.edgeInsetsAll(IsrDimens.eighteen),
-                    decoration: BoxDecoration(
-                      color: Colors.white.withValues(alpha: 0.12),
-                      shape: BoxShape.circle,
-                    ),
-                    child: Icon(
-                      Icons.lock_rounded,
-                      color: Colors.white,
-                      size: IsrDimens.forty,
-                    ),
-                  ),
-                  IsrDimens.boxHeight(IsrDimens.sixteen),
-                  Text(
-                    IsrTranslationFile.paidPostLockedTitle,
-                    textAlign: TextAlign.center,
-                    style: TextStyle(
-                      color: Colors.white,
-                      fontSize: IsrDimens.eighteen,
-                      fontWeight: FontWeight.w600,
-                      shadows: _textShadows,
-                    ),
-                  ),
-                  IsrDimens.boxHeight(IsrDimens.eight),
-                  Text(
-                    IsrTranslationFile.paidPostLockedSubtitle,
-                    textAlign: TextAlign.center,
-                    style: TextStyle(
-                      color: Colors.white.withValues(alpha: 0.88),
-                      fontSize: IsrDimens.fourteen,
-                      height: 1.35,
-                    ),
-                  ),
-                  IsrDimens.boxHeight(IsrDimens.twentyTwo),
-                  OutlinedButton(
-                    onPressed: _onPaidUnlockPressed,
-                    style: OutlinedButton.styleFrom(
-                      foregroundColor: primary,
-                      side: BorderSide(color: primary.withValues(alpha: 0.9)),
-                      padding: IsrDimens.edgeInsetsSymmetric(
-                        horizontal: IsrDimens.twentyTwo,
-                        vertical: IsrDimens.twelve,
+    Widget chrome({Widget? blurredChild}) => Stack(
+          fit: StackFit.expand,
+          children: [
+            if (blurredChild != null)
+              ImageFiltered(
+                imageFilter:
+                    ImageFilter.blur(sigmaX: blurSigma, sigmaY: blurSigma),
+                child: blurredChild,
+              )
+            else
+              ColoredBox(color: Colors.grey.shade900),
+            Container(color: Colors.black.withValues(alpha: 0.42)),
+            Center(
+              child: Padding(
+                padding: IsrDimens.edgeInsetsSymmetric(
+                    horizontal: IsrDimens.twentyEight),
+                child: Column(
+                  mainAxisSize: MainAxisSize.min,
+                  children: [
+                    Container(
+                      padding: IsrDimens.edgeInsetsAll(IsrDimens.eighteen),
+                      decoration: BoxDecoration(
+                        color: Colors.white.withValues(alpha: 0.12),
+                        shape: BoxShape.circle,
                       ),
-                      shape: RoundedRectangleBorder(
-                        borderRadius: BorderRadius.circular(IsrDimens.twentyFive),
+                      child: Icon(
+                        Icons.lock_rounded,
+                        color: Colors.white,
+                        size: IsrDimens.forty,
                       ),
                     ),
-                    child: Text(
-                      _paidUnlockPriceLabel().isEmpty
-                          ? IsrTranslationFile.unlockFor
-                          : '${IsrTranslationFile.unlockFor} ${_paidUnlockPriceLabel()}',
+                    IsrDimens.boxHeight(IsrDimens.sixteen),
+                    Text(
+                      IsrTranslationFile.paidPostLockedTitle,
+                      textAlign: TextAlign.center,
                       style: TextStyle(
+                        color: Colors.white,
+                        fontSize: IsrDimens.eighteen,
                         fontWeight: FontWeight.w600,
-                        fontSize: IsrDimens.fifteen,
+                        shadows: _textShadows,
                       ),
                     ),
-                  ),
-                ],
+                    IsrDimens.boxHeight(IsrDimens.eight),
+                    Text(
+                      IsrTranslationFile.paidPostLockedSubtitle,
+                      textAlign: TextAlign.center,
+                      style: TextStyle(
+                        color: Colors.white.withValues(alpha: 0.88),
+                        fontSize: IsrDimens.fourteen,
+                        height: 1.35,
+                      ),
+                    ),
+                    IsrDimens.boxHeight(IsrDimens.twentyTwo),
+                    OutlinedButton(
+                      onPressed: _onPaidUnlockPressed,
+                      style: OutlinedButton.styleFrom(
+                        foregroundColor: primary,
+                        side: BorderSide(color: primary.withValues(alpha: 0.9)),
+                        padding: IsrDimens.edgeInsetsSymmetric(
+                          horizontal: IsrDimens.twentyTwo,
+                          vertical: IsrDimens.twelve,
+                        ),
+                        shape: RoundedRectangleBorder(
+                          borderRadius:
+                              BorderRadius.circular(IsrDimens.twentyFive),
+                        ),
+                      ),
+                      child: Text(
+                        _paidUnlockPriceLabel().isEmpty
+                            ? IsrTranslationFile.unlockFor
+                            : '${IsrTranslationFile.unlockFor} ${_paidUnlockPriceLabel()}',
+                        style: TextStyle(
+                          fontWeight: FontWeight.w600,
+                          fontSize: IsrDimens.fifteen,
+                        ),
+                      ),
+                    ),
+                  ],
+                ),
               ),
             ),
-          ),
-        ],
-      );
-    }
+          ],
+        );
 
     final imageUrl = _paidLockStillImageUrl();
     if (imageUrl == null || imageUrl.isStringEmptyOrNull == true) {
@@ -983,7 +978,8 @@ class _IsmReelsVideoPlayerViewState extends State<IsmReelsVideoPlayerView>
                 child: Container(
                   decoration: BoxDecoration(
                     color: _mediaIndicatorConfig?.progressColor ??
-                        IsrColors.appColor.applyOpacity(0.5), // Pure white for progressed
+                        IsrColors.appColor
+                            .applyOpacity(0.5), // Pure white for progressed
                     borderRadius: borderRadius,
                   ),
                 ),
@@ -1014,7 +1010,8 @@ class _IsmReelsVideoPlayerViewState extends State<IsmReelsVideoPlayerView>
               child: Container(
                 decoration: BoxDecoration(
                   color: _mediaIndicatorConfig?.progressColor ??
-                      IsrColors.appColor.applyOpacity(0.5), // Pure white for progressed
+                      IsrColors.appColor
+                          .applyOpacity(0.5), // Pure white for progressed
                   borderRadius: borderRadius,
                 ),
               ),
@@ -1239,20 +1236,18 @@ class _IsmReelsVideoPlayerViewState extends State<IsmReelsVideoPlayerView>
         // Only the main GestureDetector as child of the outer Stack
         GestureDetector(
           onTap: _shouldShowPaidLockOverlay ? null : _toggleMuteAndUnMute,
-          onLongPressStart: _shouldShowPaidLockOverlay
-              ? null
-              : (_) => _togglePlayPause(),
+          onLongPressStart:
+              _shouldShowPaidLockOverlay ? null : (_) => _togglePlayPause(),
           onDoubleTap:
               _shouldShowPaidLockOverlay ? null : _triggerLikeAnimation,
-          onLongPressEnd: _shouldShowPaidLockOverlay
-              ? null
-              : (_) => _resumePlayback(),
+          onLongPressEnd:
+              _shouldShowPaidLockOverlay ? null : (_) => _resumePlayback(),
           child: Stack(
             fit: StackFit.expand,
             alignment: Alignment.center,
             children: [
               _buildMediaContent(),
-              if (_showLikeAnimation)
+              if (!_shouldShowPaidLockOverlay && _showLikeAnimation)
                 Center(
                   child: Lottie.asset(
                     AssetConstants.heartAnimation,
@@ -1261,9 +1256,8 @@ class _IsmReelsVideoPlayerViewState extends State<IsmReelsVideoPlayerView>
                     repeat: false,
                   ),
                 ),
-              if (_showMuteAnimation &&
-                  !_shouldShowPaidLockOverlay &&
-                  _reelData.mediaMetaDataList.isNotEmpty &&
+              if (!_shouldShowPaidLockOverlay &&
+                  _showMuteAnimation &&
                   _reelData.mediaMetaDataList[_currentPageNotifier.value]
                           .mediaType ==
                       kVideoType)
@@ -1335,18 +1329,20 @@ class _IsmReelsVideoPlayerViewState extends State<IsmReelsVideoPlayerView>
 
               //right action
               //kept separate so that it does not bloc touch/gesture to underlying widgets
-              Positioned(
-                right: widget.reelsConfig.overlayPadding
-                        ?.resolve(TextDirection.ltr)
-                        .right ??
-                    0,
-                bottom: widget.reelsConfig.overlayPadding
-                        ?.resolve(TextDirection.ltr)
-                        .bottom ??
-                    0,
-                child: widget.reelsConfig.actionWidget?.call(_reelData).child ??
-                    _buildRightSideActions(),
-              ),
+              if (!_shouldShowPaidLockOverlay)
+                Positioned(
+                  right: widget.reelsConfig.overlayPadding
+                          ?.resolve(TextDirection.ltr)
+                          .right ??
+                      0,
+                  bottom: widget.reelsConfig.overlayPadding
+                          ?.resolve(TextDirection.ltr)
+                          .bottom ??
+                      0,
+                  child:
+                      widget.reelsConfig.actionWidget?.call(_reelData).child ??
+                          _buildRightSideActions(),
+                ),
 
               //bottom section
               //kept separate so that it does not bloc touch/gesture to underlying widgets
@@ -2094,165 +2090,162 @@ class _IsmReelsVideoPlayerViewState extends State<IsmReelsVideoPlayerView>
         ? (_reelData.postData as TimeLineData).user
         : null;
     return FollowActionWidget(
-        postId: _reelData.postId ?? '',
-        userId: _reelData.userId ?? '',
-        isTargetPrivate: (timelineUser?.isPrivate ?? 0) == 1,
-        initialFollowStatus: timelineUser?.followStatus,
-        initialIsRequested: timelineUser?.isRequested,
-        builder: (isLoading, isFollowing, followRequestPending, onTap) {
-          // Update reel data state (non-blocking, for UI sync)
-          _reelData.isFollow = isFollowing;
+      postId: _reelData.postId ?? '',
+      userId: _reelData.userId ?? '',
+      isTargetPrivate: (timelineUser?.isPrivate ?? 0) == 1,
+      initialFollowStatus: timelineUser?.followStatus,
+      initialIsRequested: timelineUser?.isRequested,
+      builder: (isLoading, isFollowing, followRequestPending, onTap) {
+        // Update reel data state (non-blocking, for UI sync)
+        _reelData.isFollow = isFollowing;
 
-          // Show loading indicator during API call
-          if (isLoading) {
-            return Container(
-              width:
+        // Show loading indicator during API call
+        if (isLoading) {
+          return Container(
+            width: _followButtonConfig?.followButtonMinWidth ?? IsrDimens.sixty,
+            height:
+                _followButtonConfig?.followButtonHeight ?? IsrDimens.twentyFour,
+            decoration: BoxDecoration(
+              color: Theme.of(context).primaryColor.withValues(alpha: 0.7),
+              borderRadius: BorderRadius.circular(IsrDimens.twenty),
+            ),
+            child: Center(
+              child: SizedBox(
+                width: 16,
+                height: 16,
+                child: CircularProgressIndicator(
+                  strokeWidth: 2,
+                  valueColor: AlwaysStoppedAnimation<Color>(
+                    _followButtonConfig?.loadingIndicatorColor ??
+                        IsrColors.white,
+                  ),
+                ),
+              ),
+            ),
+          );
+        } else if (followRequestPending &&
+            _reelData.postSetting?.isUnFollowButtonVisible == true) {
+          return Container(
+            height:
+                _followButtonConfig?.followButtonHeight ?? IsrDimens.twentyFour,
+            decoration: _followButtonConfig?.followingButtonDecoration ??
+                BoxDecoration(
+                  borderRadius: BorderRadius.circular(IsrDimens.twenty),
+                  border: Border.all(
+                      color: Theme.of(context).primaryColor,
+                      width: IsrDimens.two),
+                ),
+            child: MaterialButton(
+              minWidth:
                   _followButtonConfig?.followButtonMinWidth ?? IsrDimens.sixty,
               height: _followButtonConfig?.followButtonHeight ??
                   IsrDimens.twentyFour,
-              decoration: BoxDecoration(
-                color: Theme.of(context).primaryColor.withValues(alpha: 0.7),
-                borderRadius: BorderRadius.circular(IsrDimens.twenty),
+              padding: _followButtonConfig?.followButtonPadding ??
+                  IsrDimens.edgeInsetsSymmetric(horizontal: IsrDimens.twelve),
+              shape: RoundedRectangleBorder(
+                  borderRadius: BorderRadius.circular(IsrDimens.twenty)),
+              onPressed: () => onTap(
+                reelData: _reelData,
+                postSectionType: widget.postSectionType,
+                watchDuration: _postWatchDuration.inSeconds,
+                apiCallBack: widget.onPressFollowButton != null
+                    ? () => widget.onPressFollowButton!(_reelData, isFollowing)
+                    : null,
               ),
-              child: Center(
-                child: SizedBox(
-                  width: 16,
-                  height: 16,
-                  child: CircularProgressIndicator(
-                    strokeWidth: 2,
-                    valueColor: AlwaysStoppedAnimation<Color>(
-                      _followButtonConfig?.loadingIndicatorColor ??
-                          IsrColors.white,
+              child: Text(
+                IsrTranslationFile.requested,
+                style: _textStyleConfig?.followingButtonTextStyle ??
+                    IsrStyles.primaryText12.copyWith(
+                      fontWeight: FontWeight.w600,
+                      color: IsrColors.colorF4F4F4,
                     ),
-                  ),
-                ),
               ),
-            );
-          } else if (followRequestPending &&
-              _reelData.postSetting?.isUnFollowButtonVisible == true) {
-            return Container(
-              height: _followButtonConfig?.followButtonHeight ??
-                  IsrDimens.twentyFour,
-              decoration: _followButtonConfig?.followingButtonDecoration ??
-                  BoxDecoration(
-                    borderRadius: BorderRadius.circular(IsrDimens.twenty),
-                    border: Border.all(
-                        color: Theme.of(context).primaryColor,
-                        width: IsrDimens.two),
-                  ),
-              child: MaterialButton(
-                minWidth: _followButtonConfig?.followButtonMinWidth ??
-                    IsrDimens.sixty,
-                height: _followButtonConfig?.followButtonHeight ??
-                    IsrDimens.twentyFour,
-                padding: _followButtonConfig?.followButtonPadding ??
-                    IsrDimens.edgeInsetsSymmetric(horizontal: IsrDimens.twelve),
-                shape: RoundedRectangleBorder(
-                    borderRadius: BorderRadius.circular(IsrDimens.twenty)),
-                onPressed: () => onTap(
-                  reelData: _reelData,
-                  postSectionType: widget.postSectionType,
-                  watchDuration: _postWatchDuration.inSeconds,
-                  apiCallBack: widget.onPressFollowButton != null
-                      ? () =>
-                          widget.onPressFollowButton!(_reelData, isFollowing)
-                      : null,
-                ),
-                child: Text(
-                  IsrTranslationFile.requested,
-                  style: _textStyleConfig?.followingButtonTextStyle ??
-                      IsrStyles.primaryText12.copyWith(
-                        fontWeight: FontWeight.w600,
-                        color: IsrColors.colorF4F4F4,
-                      ),
-                ),
-              ),
-            );
-          } else if (!isFollowing &&
-              !followRequestPending &&
-              _reelData.postSetting?.isUnFollowButtonVisible == true) {
-            final private = (timelineUser?.isPrivate ?? 0) == 1;
-            final showRequest = FollowRelationshipUi.showRequestPrimaryLabel(
-              isFollowing: isFollowing,
-              isPrivateAccount: private,
-              isRequested: timelineUser?.isRequested,
-              followStatus: timelineUser?.followStatus,
-            );
-            return Container(
-              height: _followButtonConfig?.followButtonHeight ??
-                  IsrDimens.twentyFour,
-              decoration: _followButtonConfig?.followButtonDecoration ??
-                  BoxDecoration(
-                    color: Theme.of(context).primaryColor,
-                    borderRadius: BorderRadius.circular(IsrDimens.twenty),
-                  ),
-              child: MaterialButton(
-                minWidth: _followButtonConfig?.followButtonMinWidth ??
-                    IsrDimens.sixty,
-                height: _followButtonConfig?.followButtonHeight ??
-                    IsrDimens.twentyFour,
-                padding: _followButtonConfig?.followButtonPadding ??
-                    IsrDimens.edgeInsetsSymmetric(horizontal: IsrDimens.twelve),
-                shape: RoundedRectangleBorder(
-                    borderRadius: BorderRadius.circular(IsrDimens.twenty)),
-                onPressed: () => onTap(
-                  reelData: _reelData,
-                  postSectionType: widget.postSectionType,
-                  watchDuration: _postWatchDuration.inSeconds,
-                  apiCallBack: widget.onPressFollowButton != null
-                      ? () =>
-                          widget.onPressFollowButton!(_reelData, isFollowing)
-                      : null,
-                ),
-                child: Text(
-                  showRequest
-                      ? IsrTranslationFile.request
-                      : IsrTranslationFile.follow,
-                  style: _textStyleConfig?.followButtonTextStyle ??
-                      IsrStyles.white12.copyWith(
-                        fontWeight: FontWeight.w600,
-                      ),
-                ),
-              ),
-            );
-          } else if (isFollowing &&
-              _reelData.postSetting?.isFollowButtonVisible == true) {
-            return Container(
-              height: _followButtonConfig?.followButtonHeight ??
-                  IsrDimens.twentyFour,
-              decoration: _followButtonConfig?.followingButtonDecoration ??
-                  BoxDecoration(
-                    borderRadius: BorderRadius.circular(IsrDimens.twenty),
-                    border: Border.all(
-                        color: Theme.of(context).primaryColor,
-                        width: IsrDimens.two),
-                  ),
-              child: MaterialButton(
-                minWidth: _followButtonConfig?.followButtonMinWidth ??
-                    IsrDimens.sixty,
-                height: _followButtonConfig?.followButtonHeight ??
-                    IsrDimens.twentyFour,
-                padding: _followButtonConfig?.followButtonPadding ??
-                    IsrDimens.edgeInsetsSymmetric(horizontal: IsrDimens.twelve),
-                shape: RoundedRectangleBorder(
+            ),
+          );
+        } else if (!isFollowing &&
+            !followRequestPending &&
+            _reelData.postSetting?.isUnFollowButtonVisible == true) {
+          final private = (timelineUser?.isPrivate ?? 0) == 1;
+          final showRequest = FollowRelationshipUi.showRequestPrimaryLabel(
+            isFollowing: isFollowing,
+            isPrivateAccount: private,
+            isRequested: timelineUser?.isRequested,
+            followStatus: timelineUser?.followStatus,
+          );
+          return Container(
+            height:
+                _followButtonConfig?.followButtonHeight ?? IsrDimens.twentyFour,
+            decoration: _followButtonConfig?.followButtonDecoration ??
+                BoxDecoration(
+                  color: Theme.of(context).primaryColor,
                   borderRadius: BorderRadius.circular(IsrDimens.twenty),
                 ),
-                onPressed: () => onTap(reelData: _reelData),
-                // <-- your unfollow logic
-                child: Text(
-                  IsrTranslationFile.following,
-                  style: _textStyleConfig?.followingButtonTextStyle ??
-                      IsrStyles.primaryText12.copyWith(
-                        fontWeight: FontWeight.w600,
-                        color: IsrColors.colorF4F4F4,
-                      ),
-                ),
+            child: MaterialButton(
+              minWidth:
+                  _followButtonConfig?.followButtonMinWidth ?? IsrDimens.sixty,
+              height: _followButtonConfig?.followButtonHeight ??
+                  IsrDimens.twentyFour,
+              padding: _followButtonConfig?.followButtonPadding ??
+                  IsrDimens.edgeInsetsSymmetric(horizontal: IsrDimens.twelve),
+              shape: RoundedRectangleBorder(
+                  borderRadius: BorderRadius.circular(IsrDimens.twenty)),
+              onPressed: () => onTap(
+                reelData: _reelData,
+                postSectionType: widget.postSectionType,
+                watchDuration: _postWatchDuration.inSeconds,
+                apiCallBack: widget.onPressFollowButton != null
+                    ? () => widget.onPressFollowButton!(_reelData, isFollowing)
+                    : null,
               ),
-            );
-          }
-          return const SizedBox.shrink();
-        },
-      );
+              child: Text(
+                showRequest
+                    ? IsrTranslationFile.request
+                    : IsrTranslationFile.follow,
+                style: _textStyleConfig?.followButtonTextStyle ??
+                    IsrStyles.white12.copyWith(
+                      fontWeight: FontWeight.w600,
+                    ),
+              ),
+            ),
+          );
+        } else if (isFollowing &&
+            _reelData.postSetting?.isFollowButtonVisible == true) {
+          return Container(
+            height:
+                _followButtonConfig?.followButtonHeight ?? IsrDimens.twentyFour,
+            decoration: _followButtonConfig?.followingButtonDecoration ??
+                BoxDecoration(
+                  borderRadius: BorderRadius.circular(IsrDimens.twenty),
+                  border: Border.all(
+                      color: Theme.of(context).primaryColor,
+                      width: IsrDimens.two),
+                ),
+            child: MaterialButton(
+              minWidth:
+                  _followButtonConfig?.followButtonMinWidth ?? IsrDimens.sixty,
+              height: _followButtonConfig?.followButtonHeight ??
+                  IsrDimens.twentyFour,
+              padding: _followButtonConfig?.followButtonPadding ??
+                  IsrDimens.edgeInsetsSymmetric(horizontal: IsrDimens.twelve),
+              shape: RoundedRectangleBorder(
+                borderRadius: BorderRadius.circular(IsrDimens.twenty),
+              ),
+              onPressed: () => onTap(reelData: _reelData),
+              // <-- your unfollow logic
+              child: Text(
+                IsrTranslationFile.following,
+                style: _textStyleConfig?.followingButtonTextStyle ??
+                    IsrStyles.primaryText12.copyWith(
+                      fontWeight: FontWeight.w600,
+                      color: IsrColors.colorF4F4F4,
+                    ),
+              ),
+            ),
+          );
+        }
+        return const SizedBox.shrink();
+      },
+    );
   }
 
   Future<void> _triggerLikeAnimation() async {

--- a/lib/presentation/screens/posts/ism_reels_video_player_view.dart
+++ b/lib/presentation/screens/posts/ism_reels_video_player_view.dart
@@ -1,5 +1,6 @@
 import 'dart:async';
 import 'dart:convert';
+import 'dart:ui' show ImageFilter;
 
 import 'package:flutter/gestures.dart';
 import 'package:flutter/material.dart';
@@ -260,6 +261,104 @@ class _IsmReelsVideoPlayerViewState extends State<IsmReelsVideoPlayerView>
   /// Returns true if the current post has multiple media items (carousel).
   bool get _hasMultipleMedia => _reelData.mediaMetaDataList.length > 1;
 
+  bool get _isViewerPostAuthor {
+    final uid = widget.loggedInUserId;
+    if (uid.isStringEmptyOrNull == true) return false;
+    return uid == _reelData.userId;
+  }
+
+  /// Locked paid post for feeds: blur + lock overlay for viewers who do not own the post.
+  bool get _shouldShowPaidLockOverlay {
+    if (_isViewerPostAuthor) return false;
+    if (_reelData.isLocked != true) return false;
+    final reason = (_reelData.lockReason ?? '').toLowerCase();
+    final isPaidLocked = reason == 'paid' || (_reelData.isPaid == true);
+    return isPaidLocked;
+  }
+
+  TimeLineData? get _timelinePost =>
+      _reelData.postData is TimeLineData ? _reelData.postData as TimeLineData : null;
+
+  static bool _looksLikeStreamingOrVideoUrl(String url) {
+    final u = url.trim().toLowerCase();
+    if (u.isEmpty) return false;
+    return u.endsWith('.mp4') ||
+        u.endsWith('.mov') ||
+        u.endsWith('.m3u8') ||
+        u.endsWith('.webm') ||
+        u.endsWith('.m4v') ||
+        u.contains('.m3u8');
+  }
+
+  /// Paid-locked posts show a blurred still frame only — never decode the video URL in an image widget.
+  String? _paidLockStillImageUrl() {
+    String? usableStill(String? candidate) {
+      final s = candidate?.trim() ?? '';
+      if (s.isEmpty || _looksLikeStreamingOrVideoUrl(s)) return null;
+      return s;
+    }
+
+    Iterable<PreviewMedia> sortedPreviews() sync* {
+      final previews = _timelinePost?.previews;
+      if (previews.isListEmptyOrNull == true) return;
+      final list = List<PreviewMedia>.from(previews!)
+        ..sort((a, b) => (a.position ?? 0).compareTo(b.position ?? 0));
+      for (final p in list) {
+        yield p;
+      }
+    }
+
+    if (_reelData.mediaMetaDataList.isNotEmpty) {
+      final meta =
+          _reelData.mediaMetaDataList[_currentPageNotifier.value];
+      if (meta.mediaType == kVideoType) {
+        final thumb = usableStill(meta.thumbnailUrl);
+        if (thumb != null) return thumb;
+        for (final p in sortedPreviews()) {
+          final hit = usableStill(p.url);
+          if (hit != null) return hit;
+        }
+        return null;
+      }
+      final fromMedia = usableStill(meta.mediaUrl);
+      if (fromMedia != null) return fromMedia;
+      final fromThumb = usableStill(meta.thumbnailUrl);
+      if (fromThumb != null) return fromThumb;
+    }
+
+    for (final p in sortedPreviews()) {
+      final hit = usableStill(p.url);
+      if (hit != null) return hit;
+    }
+    return null;
+  }
+
+  String _paidUnlockPriceLabel() {
+    final raw = _reelData.priceAmount;
+    if (raw == null) return '';
+    final amount = raw is num ? raw.toString() : raw.toString().trim();
+    if (amount.isEmpty) return '';
+    final c = (_reelData.priceCurrency ?? '').trim().toLowerCase();
+    if (c.isEmpty || c == '-') return amount;
+    if (c == 'coin' || c == 'coins') return '$amount coins';
+    if (c == 'usd') return '\$$amount';
+    return '$amount $c'.trim();
+  }
+
+  Future<void> _onPaidUnlockPressed() async {
+    final cb = _postConfig.postCallBackConfig?.onPaidPostUnlock;
+    final post = _timelinePost;
+    if (cb != null && post != null) {
+      await cb(post);
+      return;
+    }
+    Utility.showAppDialog(
+      message: _paidUnlockPriceLabel().isEmpty
+          ? IsrTranslationFile.paidPostLockedSubtitle
+          : '${IsrTranslationFile.unlockFor} ${_paidUnlockPriceLabel()}',
+    );
+  }
+
   void _onStartInit() async {
     _reelData = widget.reelsData!;
 
@@ -286,16 +385,18 @@ class _IsmReelsVideoPlayerViewState extends State<IsmReelsVideoPlayerView>
     // Initialize PageController for carousel
     _pageController = PreloadPageController(initialPage: 0);
 
-    // Preload next videos for smoother experience
-    _preloadNextVideos();
+    if (_reelData.mediaMetaDataList.isEmpty) {
+      unawaited(_fetchFloatingCommentsIfNeeded());
+      return;
+    }
 
-    //resent image progress
-    _resetPostProgress();
-
-    // Start image view timer only if current media is an image
-    if (_reelData.mediaMetaDataList[_currentPageNotifier.value].mediaType ==
-        kPictureType) {
-      _startOrResumeImageProgress();
+    if (!_shouldShowPaidLockOverlay) {
+      _preloadNextVideos();
+      _resetPostProgress();
+      if (_reelData.mediaMetaDataList[_currentPageNotifier.value].mediaType ==
+          kPictureType) {
+        _startOrResumeImageProgress();
+      }
     }
 
     unawaited(_fetchFloatingCommentsIfNeeded());
@@ -519,7 +620,121 @@ class _IsmReelsVideoPlayerViewState extends State<IsmReelsVideoPlayerView>
         ),
       );
 
+  Widget _buildPaidLockedLayer() {
+    const blurSigma = 28.0;
+    final primary = Theme.of(context).colorScheme.primary;
+
+    Widget chrome({Widget? blurredChild}) {
+      return Stack(
+        fit: StackFit.expand,
+        children: [
+          if (blurredChild != null)
+            ImageFiltered(
+              imageFilter:
+                  ImageFilter.blur(sigmaX: blurSigma, sigmaY: blurSigma),
+              child: blurredChild,
+            )
+          else
+            ColoredBox(color: Colors.grey.shade900),
+          Container(color: Colors.black.withValues(alpha: 0.42)),
+          Center(
+            child: Padding(
+              padding: IsrDimens.edgeInsetsSymmetric(horizontal: IsrDimens.twentyEight),
+              child: Column(
+                mainAxisSize: MainAxisSize.min,
+                children: [
+                  Container(
+                    padding: IsrDimens.edgeInsetsAll(IsrDimens.eighteen),
+                    decoration: BoxDecoration(
+                      color: Colors.white.withValues(alpha: 0.12),
+                      shape: BoxShape.circle,
+                    ),
+                    child: Icon(
+                      Icons.lock_rounded,
+                      color: Colors.white,
+                      size: IsrDimens.forty,
+                    ),
+                  ),
+                  IsrDimens.boxHeight(IsrDimens.sixteen),
+                  Text(
+                    IsrTranslationFile.paidPostLockedTitle,
+                    textAlign: TextAlign.center,
+                    style: TextStyle(
+                      color: Colors.white,
+                      fontSize: IsrDimens.eighteen,
+                      fontWeight: FontWeight.w600,
+                      shadows: _textShadows,
+                    ),
+                  ),
+                  IsrDimens.boxHeight(IsrDimens.eight),
+                  Text(
+                    IsrTranslationFile.paidPostLockedSubtitle,
+                    textAlign: TextAlign.center,
+                    style: TextStyle(
+                      color: Colors.white.withValues(alpha: 0.88),
+                      fontSize: IsrDimens.fourteen,
+                      height: 1.35,
+                    ),
+                  ),
+                  IsrDimens.boxHeight(IsrDimens.twentyTwo),
+                  OutlinedButton(
+                    onPressed: _onPaidUnlockPressed,
+                    style: OutlinedButton.styleFrom(
+                      foregroundColor: primary,
+                      side: BorderSide(color: primary.withValues(alpha: 0.9)),
+                      padding: IsrDimens.edgeInsetsSymmetric(
+                        horizontal: IsrDimens.twentyTwo,
+                        vertical: IsrDimens.twelve,
+                      ),
+                      shape: RoundedRectangleBorder(
+                        borderRadius: BorderRadius.circular(IsrDimens.twentyFive),
+                      ),
+                    ),
+                    child: Text(
+                      _paidUnlockPriceLabel().isEmpty
+                          ? IsrTranslationFile.unlockFor
+                          : '${IsrTranslationFile.unlockFor} ${_paidUnlockPriceLabel()}',
+                      style: TextStyle(
+                        fontWeight: FontWeight.w600,
+                        fontSize: IsrDimens.fifteen,
+                      ),
+                    ),
+                  ),
+                ],
+              ),
+            ),
+          ),
+        ],
+      );
+    }
+
+    final imageUrl = _paidLockStillImageUrl();
+    if (imageUrl == null || imageUrl.isStringEmptyOrNull == true) {
+      return chrome(blurredChild: null);
+    }
+
+    final blurredBackground = SizedBox.expand(
+      child: Container(
+        color: Colors.black,
+        child: Center(
+          child: _getImageWidget(
+            imageUrl: imageUrl,
+            width: IsrDimens.getScreenWidth(context),
+            height: IsrDimens.getScreenHeight(context),
+            fit: BoxFit.contain,
+            filterQuality: FilterQuality.low,
+          ),
+        ),
+      ),
+    );
+    return chrome(blurredChild: blurredBackground);
+  }
+
   Widget _buildMediaContent() {
+    if (_shouldShowPaidLockOverlay) {
+      return _buildPaidLockedLayer();
+    }
+
     Widget mediaWidget;
 
     if (_reelData.showBlur == true) {
@@ -1023,10 +1238,15 @@ class _IsmReelsVideoPlayerViewState extends State<IsmReelsVideoPlayerView>
       children: [
         // Only the main GestureDetector as child of the outer Stack
         GestureDetector(
-          onTap: _toggleMuteAndUnMute,
-          onLongPressStart: (_) => _togglePlayPause(),
-          onDoubleTap: _triggerLikeAnimation,
-          onLongPressEnd: (_) => _resumePlayback(),
+          onTap: _shouldShowPaidLockOverlay ? null : _toggleMuteAndUnMute,
+          onLongPressStart: _shouldShowPaidLockOverlay
+              ? null
+              : (_) => _togglePlayPause(),
+          onDoubleTap:
+              _shouldShowPaidLockOverlay ? null : _triggerLikeAnimation,
+          onLongPressEnd: _shouldShowPaidLockOverlay
+              ? null
+              : (_) => _resumePlayback(),
           child: Stack(
             fit: StackFit.expand,
             alignment: Alignment.center,
@@ -1042,6 +1262,8 @@ class _IsmReelsVideoPlayerViewState extends State<IsmReelsVideoPlayerView>
                   ),
                 ),
               if (_showMuteAnimation &&
+                  !_shouldShowPaidLockOverlay &&
+                  _reelData.mediaMetaDataList.isNotEmpty &&
                   _reelData.mediaMetaDataList[_currentPageNotifier.value]
                           .mediaType ==
                       kVideoType)
@@ -1064,10 +1286,11 @@ class _IsmReelsVideoPlayerViewState extends State<IsmReelsVideoPlayerView>
                 ),
 
               // show progress indicator if there are multiple videos or single media is video or autoMoveNextMedia is true
-              if (_reelData.mediaMetaDataList.isNotEmpty ||
-                  _reelData.mediaMetaDataList.firstOrNull?.mediaType ==
-                      kVideoType ||
-                  widget.onVideoCompleted != null)
+              if (!_shouldShowPaidLockOverlay &&
+                  (_reelData.mediaMetaDataList.isNotEmpty ||
+                      _reelData.mediaMetaDataList.firstOrNull?.mediaType ==
+                          kVideoType ||
+                      widget.onVideoCompleted != null))
                 Positioned(
                   bottom: widget.reelsConfig.overlayPadding
                           ?.resolve(TextDirection.ltr)

--- a/lib/res/strings/isr_translation_file.dart
+++ b/lib/res/strings/isr_translation_file.dart
@@ -71,6 +71,12 @@ class IsrTranslationFile {
   static const viewMore = 'View More';
   static const viewLess = 'View Less';
 
+  /// Shown when a post is locked as paid content (viewer is not the author).
+  static const String paidPostLockedTitle = 'Paid content';
+  static const String paidPostLockedSubtitle =
+      'Unlock this post to view the full media.';
+  static const String unlockFor = 'Unlock for';
+
   static const uploadPhotoOrVideo = 'Upload a photo or a video';
   static const uploadPhotoOrVideoToInspire =
       'Upload a photo or a video to inspire and connect with our ${AppConstants.appName} community.';


### PR DESCRIPTION
<!-- kody-pr-summary:start -->
This pull request introduces support for paid content posts within the social media platform. It adds new fields and logic to handle paid post settings, including whether a post is marked as paid, the price amount, and currency. The UI is updated to allow users to specify a paid amount and toggle paid post options, with validation ensuring the amount is greater than zero. When viewing paid-locked posts, the app displays a blurred overlay with a lock icon and an option to unlock the content, which triggers a callback for the host app to handle the purchase flow. Additionally, the data models and API request payloads are extended to include paid content information, ensuring proper serialization and deserialization. Overall, these changes enable content creators to monetize their posts and viewers to unlock paid media, enhancing the platform's monetization capabilities.
<!-- kody-pr-summary:end -->