### PR TITLE
Bugfix/new social flow tfm bug fix vnk 02 06

### DIFF
--- a/lib/presentation/screens/posts/ism_post_view.dart
+++ b/lib/presentation/screens/posts/ism_post_view.dart
@@ -1009,7 +1009,6 @@ class _PostViewState extends State<IsmPostView> with TickerProviderStateMixin {
             builder: (_) => ReportReasonDialog(
               reasonFor: ReasonsFor.socialPost,
               contentId: postDataModel.id ?? '',
-              showToastOnSuccess: false,
               onReportInvoked: (reason) {
                 completer.complete(true);
               },
@@ -1017,9 +1016,6 @@ class _PostViewState extends State<IsmPostView> with TickerProviderStateMixin {
                 completer.complete(false);
               },
               onReportSuccess: (reason) {
-                Utility.showInSnackBar(
-                    IsrTranslationFile.postReportedSuccessfully, context,
-                    isSuccessIcon: true);
                 _logReportEvent(postDataModel, reason.name ?? '', tabData);
               },
             ),

--- a/lib/presentation/screens/posts/post_item_widget.dart
+++ b/lib/presentation/screens/posts/post_item_widget.dart
@@ -437,18 +437,8 @@ class _PostItemWidgetState extends State<PostItemWidget>
                       onPressSaveButton: widget.reelsConfig.onPressSave,
                       onTapMentionTag: (mentionedList) async {
                         if (widget.reelsConfig.onTapMentionTag != null) {
-                          final result = await widget.reelsConfig
-                              .onTapMentionTag!(reelsData, mentionedList);
-                          if (result.isListEmptyOrNull == false) {
-                            final index = _reelsDataList.indexWhere((element) =>
-                                element.postId == reelsData.postId);
-                            if (index != -1) {
-                              _reelsDataList[index].mentions = result ?? [];
-                              _refreshCounts[index] =
-                                  (_refreshCounts[index] ?? 0) + 1;
-                              _updateState();
-                            }
-                          }
+                          await widget.reelsConfig.onTapMentionTag!(reelsData, mentionedList);
+                          // for untagging, do so from IsmSocialActionCubit
                         }
                       },
                       onTapCartIcon: (productId) {


### PR DESCRIPTION
<!-- kody-pr-summary:start -->
This pull request addresses specific UI and functionality adjustments within the social post flow. It removes the `showToastOnSuccess` parameter from the `ReportReasonDialog`, indicating that success toast notifications are no longer automatically shown upon reporting a post. Instead, the code now explicitly logs the report event without displaying a success message. Additionally, it simplifies the handling of mention tags in the post item widget by removing redundant result checks and comments, streamlining the process for tagging and untagging mentions. Overall, these changes improve the reporting flow by removing automatic success notifications and clarify the mention tagging logic for better maintainability.
<!-- kody-pr-summary:end -->