### PR TITLE
refactor: Remove host bottom navigation bar clearance from overlay in…

### DIFF
--- a/lib/presentation/screens/posts/ism_post_view.dart
+++ b/lib/presentation/screens/posts/ism_post_view.dart
@@ -824,7 +824,6 @@ class _PostViewState extends State<IsmPostView> with TickerProviderStateMixin {
     final bottom = IsrDimens.resolveOverlayBottomInset(
       context,
       overlay,
-      includeHostBottomNav: !widget.isOverlayPlayer,
     );
     if (overlay == null) {
       return EdgeInsets.only(bottom: bottom);
@@ -1130,7 +1129,6 @@ class _PostViewState extends State<IsmPostView> with TickerProviderStateMixin {
       IsrDimens.resolveOverlayBottomInset(
         context,
         _postConfig.postUIConfig?.overlayPadding,
-        includeHostBottomNav: !widget.isOverlayPlayer,
       );
 
   Widget _buildTabBar() {

--- a/lib/presentation/screens/posts/ism_reels_video_player_view.dart
+++ b/lib/presentation/screens/posts/ism_reels_video_player_view.dart
@@ -106,8 +106,6 @@ class _IsmReelsVideoPlayerViewState extends State<IsmReelsVideoPlayerView>
       IsrDimens.resolveOverlayBottomInset(
         context,
         widget.reelsConfig.overlayPadding,
-        includeHostBottomNav:
-            !IsrVideoReelConfig.isOverlayReelsPlayerActive,
       );
 
   // Add constants for media types

--- a/lib/res/isr_dimens.dart
+++ b/lib/res/isr_dimens.dart
@@ -162,13 +162,6 @@ class IsrDimens {
   static EdgeInsets getSafeAreaPadding(BuildContext context) =>
       MediaQuery.of(context).padding;
 
-  /// Height of a host app bottom navigation bar overlaid on the feed.
-  static const double hostBottomNavBarHeight = 70;
-
-  /// Space needed so reel overlays clear the host bottom nav and system inset.
-  static double hostBottomNavClearance(BuildContext context) =>
-      MediaQuery.paddingOf(context).bottom + hostBottomNavBarHeight;
-
   /// Resolves configured overlay padding.
   ///
   /// When [includeHostBottomNav] is true (main reels tab), enforces at least
@@ -177,17 +170,14 @@ class IsrDimens {
   /// `bottom: 0` is honored instead of falling back to nav-bar clearance.
   static double resolveOverlayBottomInset(
     BuildContext context,
-    EdgeInsetsGeometry? overlayPadding, {
-    bool includeHostBottomNav = true,
-  }) {
+    EdgeInsetsGeometry? overlayPadding,
+      ) {
     final safeBottom = MediaQuery.paddingOf(context).bottom;
-    final hostClearance = safeBottom +
-        (includeHostBottomNav ? hostBottomNavBarHeight : 0);
-    if (overlayPadding == null) return hostClearance;
+    if (overlayPadding == null) return safeBottom;
     final resolved = overlayPadding.resolve(Directionality.of(context));
     if (resolved.bottom <= 0) {
-      return includeHostBottomNav ? hostClearance : safeBottom;
+      return safeBottom;
     }
-    return resolved.bottom >= hostClearance ? resolved.bottom : hostClearance;
+    return resolved.bottom >= safeBottom ? resolved.bottom : safeBottom;
   }
 }


### PR DESCRIPTION
…sets

- Removes the hardcoded `hostBottomNavBarHeight` and `hostBottomNavClearance` utility functions from `IsrDimens`.
- Simplifies `resolveOverlayBottomInset` to calculate bottom insets based solely on system safe area padding, removing the optional `includeHostBottomNav` parameter.
- Updates `IsmReelsVideoPlayerView` and `IsmPostView` to use the streamlined inset resolution logic.