### PR TITLE
feat(ism_data_provider): add saveUnsavePost method for handling post …

### DIFF
--- a/lib/data/ism_data_provider.dart
+++ b/lib/data/ism_data_provider.dart
@@ -174,6 +174,25 @@ class IsmDataProvider {
     );
   }
 
+  Future<void> saveUnsavePost({
+    required String postId,
+    required SocialPostAction saveAction,
+    bool isLoading = false,
+    Function(String, int)? onSuccess,
+    Function(String, int)? onError,
+  }) async {
+    await _executeApiCall(
+      apiCall: () => _savedPostUseCase.executeSavePost(
+        isLoading: isLoading,
+        postId: postId,
+        socialPostAction: saveAction,
+      ),
+      toJson: (data) => data?.toMap() ?? {},
+      onSuccess: onSuccess,
+      onError: onError,
+    );
+  }
+
   /// Create collection
   /// `requestMap` is a `Map` containing the following properties:
   /// - `description`: A description of the collection


### PR DESCRIPTION
<!-- kody-pr-summary:start -->
This pull request adds a new method `saveUnsavePost` to the `IsmDataProvider` class, enabling the application to handle saving or unsaving a social post. The method executes an API call to perform the save or unsave action based on the provided `saveAction` parameter, and supports optional loading state, success, and error callbacks. This enhancement facilitates user interactions related to saving or removing posts within the social feed.
<!-- kody-pr-summary:end -->