### PR TITLE
fix:- video playback visibility and state synchronization

### DIFF
--- a/lib/presentation/screens/posts/ism_post_view.dart
+++ b/lib/presentation/screens/posts/ism_post_view.dart
@@ -839,13 +839,11 @@ class _PostViewState extends State<IsmPostView> with TickerProviderStateMixin {
 
   ReelsConfig _getReelsConfig(BuildContext context, TabStateModel tabState) {
     final tabData = tabState.tabDataModel;
-    final tabIndex = _tabDataModelList.indexOf(tabState);
     return ReelsConfig(
       postConfig: _postConfig,
       isTabVisible: () {
         if (widget.isOverlayPlayer) return tabState.isVisible;
         if (!IsrVideoReelConfig.isHostFeedTabVisible) return false;
-        if (tabIndex == _currentIndex) return true;
         return tabState.isVisible;
       },
       overlayPadding: _resolvedReelsOverlayPadding(context),

--- a/lib/presentation/screens/posts/video_player_widget.dart
+++ b/lib/presentation/screens/posts/video_player_widget.dart
@@ -110,7 +110,7 @@ class _VideoPlayerWidgetState extends State<VideoPlayerWidget> {
   bool get _parentWantsVisible => widget.isParentVisible?.call() ?? true;
 
   bool get _effectiveVisible =>
-      widget.visibilityManagedByParent ? _parentWantsVisible : _isVisible;
+      widget.visibilityManagedByParent ? _parentWantsVisible : (_isVisible && _parentWantsVisible);
 
   /// Same fit for thumbnail and video so reels do not jump from letterbox to full-bleed.
   BoxFit _resolveDisplayFit({Size? videoSize}) {
@@ -215,6 +215,9 @@ class _VideoPlayerWidgetState extends State<VideoPlayerWidget> {
 
   /// Called when the video playing state changes
   void _onPlayingStateChanged() {
+    if (_isDisposed || !mounted) return;
+
+    _syncPlaybackState();
     if (_isDisposed || !mounted) return;
 
     // If video started playing, ensure UI shows the video player


### PR DESCRIPTION
- Updated `_effectiveVisible` logic in `video_player_widget.dart` to ensure parent visibility is considered even when visibility is not explicitly managed by the parent.
- Added a call to `_syncPlaybackState` within `_onPlayingStateChanged` to keep the UI and controller in sync.
- Simplified the `isTabVisible` logic in `ism_post_view.dart` by removing redundant tab index comparisons and relying on `tabState.isVisible`.