### PR TITLE
Bugfix/social v2 tfm fixes vnk 30 06

### DIFF
--- a/lib/domain/models/response/post_tab_assist.dart
+++ b/lib/domain/models/response/post_tab_assist.dart
@@ -9,6 +9,7 @@ class PostTabAssistData {
     this.userId,
     this.tagValue,
     this.tagType,
+    this.allowDuplicatePostInList = false,
   });
 
   final PostSectionType postSectionType;
@@ -22,4 +23,5 @@ class PostTabAssistData {
   String? userId;
   String? tagValue;
   TagType? tagType;
+  final bool allowDuplicatePostInList;
 }

--- a/lib/domain/models/tab_config.dart
+++ b/lib/domain/models/tab_config.dart
@@ -23,7 +23,8 @@ class TabConfig {
         tabCallBackConfig: tabCallBackConfig ?? this.tabCallBackConfig,
         tabUIConfig: tabUIConfig ?? this.tabUIConfig,
         autoMoveToNextPost: autoMoveToNextPost ?? this.autoMoveToNextPost,
-        exitOnEmptyReelsAfterModification: exitOnEmptyReelsAfterModification ?? this.exitOnEmptyReelsAfterModification,
+        exitOnEmptyReelsAfterModification:
+            exitOnEmptyReelsAfterModification ?? this.exitOnEmptyReelsAfterModification,
       );
 }
 

--- a/lib/domain/models/tab_data_model.dart
+++ b/lib/domain/models/tab_data_model.dart
@@ -26,6 +26,8 @@ class TabDataModel {
                 orElse: () => TagType.product,
               )
             : null,
+        allowDuplicatePostInList:
+            json['allowDuplicatePostInList'] as bool? ?? false,
       );
 
   TabDataModel({
@@ -39,6 +41,7 @@ class TabDataModel {
     this.initialCommentId,
     this.tagValue,
     this.tagType,
+    this.allowDuplicatePostInList = false,
   });
 
   final String title;
@@ -48,6 +51,10 @@ class TabDataModel {
 
   /// Per-tab layout: full-screen reels or scrollable post cards.
   final FeedLayoutType feedLayoutType;
+
+  /// When true, pagination / load-more appends posts even if the same post id
+  /// already exists in this tab's list. Default false keeps de-dupe behavior.
+  final bool allowDuplicatePostInList;
 
   String? userId;
   String? postId;
@@ -66,6 +73,7 @@ class TabDataModel {
     String? initialCommentId,
     String? tagValue,
     TagType? tagType,
+    bool? allowDuplicatePostInList,
   }) =>
       TabDataModel(
         title: title ?? this.title,
@@ -78,6 +86,8 @@ class TabDataModel {
         initialCommentId: initialCommentId ?? this.initialCommentId,
         tagValue: tagValue ?? this.tagValue,
         tagType: tagType ?? this.tagType,
+        allowDuplicatePostInList:
+            allowDuplicatePostInList ?? this.allowDuplicatePostInList,
       );
 
   Map<String, dynamic> toJson() => {
@@ -91,6 +101,7 @@ class TabDataModel {
         'initialCommentId': initialCommentId,
         'tagValue': tagValue,
         'tagType': tagType?.name,
+        'allowDuplicatePostInList': allowDuplicatePostInList,
       };
 }
 

--- a/lib/presentation/bloc/media_selection/media_selection_bloc.dart
+++ b/lib/presentation/bloc/media_selection/media_selection_bloc.dart
@@ -593,10 +593,12 @@ class MediaSelectionBloc
 
     try {
       if (_config == null) return null;
+      // Avoid t=0 — many videos start with a blank/white/black keyframe.
       final thumbnailFile = await VideoThumbnail.thumbnailFile(
         video: videoPath,
         thumbnailPath: (await Directory.systemTemp.createTemp()).path,
         quality: _config!.thumbnailQuality,
+        timeMs: 1500,
       );
 
       final thumbnailPath = thumbnailFile.path;

--- a/lib/presentation/bloc/posts/social_post_bloc.dart
+++ b/lib/presentation/bloc/posts/social_post_bloc.dart
@@ -134,6 +134,23 @@ class SocialPostBloc extends Bloc<SocialPostEvent, SocialPostState> {
     tab.currentPage = (pagesCovered < 1 ? 1 : pagesCovered) + 1;
   }
 
+  String? _trimmedPostId(PostTabAssistData tab) {
+    final id = tab.postId?.trim();
+    if (id == null || id.isEmpty) return null;
+    return id;
+  }
+
+  /// Moves [postId] to index 0 when present. Returns whether it was found.
+  bool _movePostToFrontIfPresent(List<TimeLineData> list, String postId) {
+    final index = list.indexWhere((p) => p.id == postId);
+    if (index < 0) return false;
+    if (index > 0) {
+      final post = list.removeAt(index);
+      list.insert(0, post);
+    }
+    return true;
+  }
+
   bool get _sdkFollowCacheOn =>
       IsrVideoReelConfig.feedCacheConfig != null &&
       IsrFeedCacheRepository.instance.isEnabled;
@@ -320,11 +337,18 @@ class SocialPostBloc extends Bloc<SocialPostEvent, SocialPostState> {
       final useFeedHostCache = IsrVideoReelConfig.feedCacheConfig != null;
 
       if (!useFeedHostCache) {
-        emit(PostLoadingState(
-            isLoading: true, postType: postTab.postSectionType));
-        if (postTab.postList.isEmpty) {
-          if (postTab.postId?.trim().isNotEmpty == true) {
-            final postIdData = await _getPostDetails(postTab.postId ?? '');
+        final postId = _trimmedPostId(postTab);
+        final hasPosts = postTab.postList.isNotEmpty;
+        final canFetch =
+            !postTab.postSectionType.isUserDependent || isUserLoggedIn;
+
+        if (!hasPosts) {
+          // Case 1: no postId, no list → list API
+          // Case 2: postId set, no list → detail API, then list API
+          emit(PostLoadingState(
+              isLoading: true, postType: postTab.postSectionType));
+          if (postId != null) {
+            final postIdData = await _getPostDetails(postId);
             if (postIdData != null) {
               postTab.postList.add(postIdData);
               await _emitLoadedPosts(
@@ -334,12 +358,31 @@ class SocialPostBloc extends Bloc<SocialPostEvent, SocialPostState> {
               );
             }
           }
-          if (!postTab.postSectionType.isUserDependent || isUserLoggedIn) {
+          if (canFetch) {
             await _callGetTabPost(postTab, false, false, false, null);
           }
-        } else {
-          // Seeded from a previous screen — advance past those page(s).
+        } else if (postId == null) {
+          // Case 3: no postId, list seeded → show list, sync pagination
           _syncCurrentPageFromSeededList(postTab);
+        } else if (_movePostToFrontIfPresent(postTab.postList, postId)) {
+          // Case 4a: postId in seeded list → pin as first item and show
+          _syncCurrentPageFromSeededList(postTab);
+        } else {
+          // Case 4b: postId missing from seeded list → detail API, then list API
+          final postIdData = await _getPostDetails(postId);
+          if (postIdData != null) {
+            postTab.postList.insert(0, postIdData);
+            await _emitLoadedPosts(
+              emit,
+              postTab.postSectionType,
+              postTab.postList,
+            );
+          }
+          if (canFetch) {
+            await _callGetTabPost(postTab, false, false, false, null);
+          } else {
+            _syncCurrentPageFromSeededList(postTab);
+          }
         }
       } else {
         if (postTab.postList.isEmpty) {

--- a/lib/presentation/bloc/posts/social_post_bloc.dart
+++ b/lib/presentation/bloc/posts/social_post_bloc.dart
@@ -120,6 +120,20 @@ class SocialPostBloc extends Bloc<SocialPostEvent, SocialPostState> {
   bool hasTabAssistData(PostSectionType tab) =>
       _postsByTab.any((t) => t.postSectionType == tab);
 
+  /// When a tab is opened with an already-fetched list (e.g. from a previous
+  /// screen's page 1+), align [PostTabAssistData.currentPage] to the next
+  /// page so load-more does not re-request page 1.
+  void _syncCurrentPageFromSeededList(PostTabAssistData tab) {
+    if (tab.postList.isEmpty) {
+      tab.currentPage = 1;
+      return;
+    }
+    // Seeded items already represent at least page 1 from the previous screen,
+    // even when the list is shorter than [pageSize] (e.g. only 2 posts).
+    final pagesCovered = (tab.postList.length / tab.pageSize).floor();
+    tab.currentPage = (pagesCovered < 1 ? 1 : pagesCovered) + 1;
+  }
+
   bool get _sdkFollowCacheOn =>
       IsrVideoReelConfig.feedCacheConfig != null &&
       IsrFeedCacheRepository.instance.isEnabled;
@@ -323,6 +337,9 @@ class SocialPostBloc extends Bloc<SocialPostEvent, SocialPostState> {
           if (!postTab.postSectionType.isUserDependent || isUserLoggedIn) {
             await _callGetTabPost(postTab, false, false, false, null);
           }
+        } else {
+          // Seeded from a previous screen — advance past those page(s).
+          _syncCurrentPageFromSeededList(postTab);
         }
       } else {
         if (postTab.postList.isEmpty) {

--- a/lib/presentation/bloc/posts/social_post_bloc.dart
+++ b/lib/presentation/bloc/posts/social_post_bloc.dart
@@ -640,7 +640,8 @@ class SocialPostBloc extends Bloc<SocialPostEvent, SocialPostState> {
       _socialActionCubit.updatePostList(postDataList);
 
       if (isFromPagination) {
-        if (feedHostCacheOn) {
+        final allowDuplicates = tabAssistData.allowDuplicatePostInList;
+        if (feedHostCacheOn && !allowDuplicates) {
           // De-dupe by post id so cached/seeded rows don't reappear when the
           // server overlaps the next page with items we already display.
           final existingIds = tabAssistData.postList
@@ -659,16 +660,22 @@ class SocialPostBloc extends Bloc<SocialPostEvent, SocialPostState> {
         // Prepend only the API items we haven't already cached. This keeps
         // the existing seeded list visible and inserts "new posts" at the
         // top, instead of wiping cache with the first API page.
-        final existingIds = tabAssistData.postList
-            .map((p) => p.id)
-            .where((id) => id != null && id.isNotEmpty)
-            .toSet();
-        final newOnly = postDataList
-            .where((p) =>
-                p.id != null && p.id!.isNotEmpty && !existingIds.contains(p.id))
-            .toList();
-        if (newOnly.isNotEmpty) {
-          tabAssistData.postList.insertAll(0, newOnly);
+        if (tabAssistData.allowDuplicatePostInList) {
+          tabAssistData.postList.insertAll(0, postDataList);
+        } else {
+          final existingIds = tabAssistData.postList
+              .map((p) => p.id)
+              .where((id) => id != null && id.isNotEmpty)
+              .toSet();
+          final newOnly = postDataList
+              .where((p) =>
+                  p.id != null &&
+                  p.id!.isNotEmpty &&
+                  !existingIds.contains(p.id))
+              .toList();
+          if (newOnly.isNotEmpty) {
+            tabAssistData.postList.insertAll(0, newOnly);
+          }
         }
       } else {
         tabAssistData.postList

--- a/lib/presentation/screens/media/media_selection/widgets/media_grid_item_widget.dart
+++ b/lib/presentation/screens/media/media_selection/widgets/media_grid_item_widget.dart
@@ -167,10 +167,12 @@ class MediaGridItemWidget extends StatelessWidget {
 
   Future<String?> _getVideoThumbnail(String videoPath) async {
     try {
+      // Avoid t=0 — many videos start with a blank/white/black keyframe.
       final thumbnailFile = await VideoThumbnail.thumbnailFile(
         video: videoPath,
         thumbnailPath: (await Directory.systemTemp.createTemp()).path,
         quality: 50,
+        timeMs: 1500,
       );
       return thumbnailFile.path;
     } catch (e) {

--- a/lib/presentation/screens/posts/ism_post_view.dart
+++ b/lib/presentation/screens/posts/ism_post_view.dart
@@ -351,7 +351,8 @@ class _PostViewState extends State<IsmPostView> with TickerProviderStateMixin {
                 postId: _.postId,
                 userId: _.userId,
                 tagType: _.tagType,
-                tagValue: _.tagValue))
+                tagValue: _.tagValue,
+                allowDuplicatePostInList: _.allowDuplicatePostInList))
             .toList()));
   }
 
@@ -790,6 +791,8 @@ class _PostViewState extends State<IsmPostView> with TickerProviderStateMixin {
           startingPostIndex: tabState.tabDataModel.startingPostIndex,
           postSectionType: tabState.tabDataModel.postSectionType,
           feedLayoutType: tabState.tabDataModel.feedLayoutType,
+          allowDuplicatePostInList:
+              tabState.tabDataModel.allowDuplicatePostInList,
           postFeedListTopInset:
               tabState.tabDataModel.feedLayoutType == FeedLayoutType.postFeed
                   ? _overlayTabBarContentInset(context)
@@ -1080,18 +1083,24 @@ class _PostViewState extends State<IsmPostView> with TickerProviderStateMixin {
           // the timeline here yields an empty page and the UI never grows.
           final pageItems = List<TimeLineData>.from(value);
           final timeline = tabState.tabDataModel.reelsDataList;
-          final existingIds = timeline
-              .map((post) => post.id)
-              .where((id) => id != null && id.isNotEmpty)
-              .toSet();
-          final timelineOnly = pageItems
-              .where((post) =>
-                  post.id == null ||
-                  post.id!.isEmpty ||
-                  !existingIds.contains(post.id))
-              .toList();
-          if (timelineOnly.isNotEmpty) {
-            timeline.addAll(timelineOnly);
+          if (tabState.tabDataModel.allowDuplicatePostInList) {
+            if (pageItems.isNotEmpty) {
+              timeline.addAll(pageItems);
+            }
+          } else {
+            final existingIds = timeline
+                .map((post) => post.id)
+                .where((id) => id != null && id.isNotEmpty)
+                .toSet();
+            final timelineOnly = pageItems
+                .where((post) =>
+                    post.id == null ||
+                    post.id!.isEmpty ||
+                    !existingIds.contains(post.id))
+                .toList();
+            if (timelineOnly.isNotEmpty) {
+              timeline.addAll(timelineOnly);
+            }
           }
           _mappedReelsByTab.remove(section);
           _mappedReelsVersionByTab.remove(section);

--- a/lib/presentation/screens/posts/post_item_widget.dart
+++ b/lib/presentation/screens/posts/post_item_widget.dart
@@ -25,6 +25,7 @@ class PostItemWidget extends StatefulWidget {
     this.startingPostIndex = 0,
     this.loggedInUserId,
     this.allowImplicitScrolling = true,
+    this.allowDuplicatePostInList = false,
     required this.reelsDataList,
     this.videoCacheManager,
     this.getEmptyScreen,
@@ -48,6 +49,10 @@ class PostItemWidget extends StatefulWidget {
   final int? startingPostIndex;
   final String? loggedInUserId;
   final bool? allowImplicitScrolling;
+
+  /// When true, load-more appends posts even if the same post id already exists.
+  final bool allowDuplicatePostInList;
+
   final List<ReelsData> reelsDataList;
   final VideoCacheManager? videoCacheManager;
   final ReelsConfig reelsConfig;
@@ -126,10 +131,13 @@ class _PostItemWidgetState extends State<PostItemWidget>
     if (_isPostFeedLayout &&
         widget.reelsDataList.length > _reelsDataList.length &&
         _hasSameReelsPrefix(_reelsDataList, widget.reelsDataList)) {
-      final existingIds = _reelsDataList.map((e) => e.postId).toSet();
-      final appended = widget.reelsDataList
-          .where((reel) => !existingIds.contains(reel.postId))
-          .toList();
+      final allowDuplicates = widget.allowDuplicatePostInList;
+      final appended = allowDuplicates
+          ? widget.reelsDataList.sublist(_reelsDataList.length)
+          : widget.reelsDataList
+              .where((reel) =>
+                  !_reelsDataList.any((e) => e.postId == reel.postId))
+              .toList();
       if (appended.isNotEmpty) {
         _reelsDataList.addAll(appended);
         _updateState();
@@ -523,14 +531,16 @@ class _PostItemWidgetState extends State<PostItemWidget>
         onTapPlaceHolder: widget.onTapPlaceHolder,
         onReelsChange: widget.reelsConfig.onReelsChange,
         onLoadMore: () async {
+          final allowDuplicates = widget.allowDuplicatePostInList;
           if (widget.onPostFeedLoadMore != null) {
             final result = await widget.onPostFeedLoadMore!();
             if (result.items.isNotEmpty) {
-              final existingIds =
-                  _reelsDataList.map((reel) => reel.postId).toSet();
-              final appended = result.items
-                  .where((reel) => !existingIds.contains(reel.postId))
-                  .toList();
+              final appended = allowDuplicates
+                  ? result.items
+                  : result.items
+                      .where((reel) => !_reelsDataList
+                          .any((existing) => existing.postId == reel.postId))
+                      .toList();
               if (appended.isNotEmpty) {
                 _reelsDataList.addAll(appended);
                 _updateState();
@@ -545,8 +555,12 @@ class _PostItemWidgetState extends State<PostItemWidget>
           if (value.isListEmptyOrNull) {
             return const PostFeedLoadMoreResult(items: [], hasMore: false);
           }
-          final newReels = value.where((newReel) => !_reelsDataList
-              .any((existing) => existing.postId == newReel.postId));
+          final newReels = allowDuplicates
+              ? value
+              : value
+                  .where((newReel) => !_reelsDataList
+                      .any((existing) => existing.postId == newReel.postId))
+                  .toList();
           if (newReels.isNotEmpty) {
             _reelsDataList.addAll(newReels);
             _updateState();
@@ -601,9 +615,13 @@ class _PostItemWidgetState extends State<PostItemWidget>
                       widget.onLoadMore!().then(
                         (value) {
                           if (value.isListEmptyOrNull) return;
-                          final newReels = value.where((newReel) =>
-                              !_reelsDataList.any((existingReel) =>
-                                  existingReel.postId == newReel.postId));
+                          final allowDuplicates =
+                              widget.allowDuplicatePostInList;
+                          final newReels = allowDuplicates
+                              ? value
+                              : value.where((newReel) => !_reelsDataList.any(
+                                  (existingReel) =>
+                                      existingReel.postId == newReel.postId));
                           _reelsDataList.addAll(newReels);
                           if (_reelsDataList.isNotEmpty) {
                             _doMediaCaching(0);
@@ -899,8 +917,11 @@ class _PostItemWidgetState extends State<PostItemWidget>
         debugPrint('🎬 PostItemWidget: Triggering load more...');
         widget.onLoadMore!().then((value) {
           if (value.isListEmptyOrNull) return;
-          final newReels = value.where((newReel) => !_reelsDataList
-              .any((existingReel) => existingReel.postId == newReel.postId));
+          final allowDuplicates = widget.allowDuplicatePostInList;
+          final newReels = allowDuplicates
+              ? value
+              : value.where((newReel) => !_reelsDataList.any(
+                  (existingReel) => existingReel.postId == newReel.postId));
           _reelsDataList.addAll(newReels);
           if (_reelsDataList.isNotEmpty) {
             _doMediaCaching(0);

--- a/lib/utils/navigator/isr_app_navigator.dart
+++ b/lib/utils/navigator/isr_app_navigator.dart
@@ -243,6 +243,7 @@ class IsrAppNavigator {
     String? userId,
     String? postId,
     String? initialCommentId,
+    bool allowDuplicatePostInList = false,
     Function(String, String, double, double)? onTapPlace,
     TransitionType transitionType = TransitionType.rightToLeft,
   }) async {
@@ -255,6 +256,7 @@ class IsrAppNavigator {
       tagType: tagType,
       userId: userId,
       postId: postId,
+      allowDuplicatePostInList: allowDuplicatePostInList,
       initialCommentId: initialCommentId,
     );
 


### PR DESCRIPTION
<!-- kody-pr-summary:start -->
This pull request introduces a new feature to control whether duplicate posts are allowed within various post lists and feeds. Specifically, it adds an `allowDuplicatePostInList` boolean flag across multiple models, widgets, and components related to post and reel lists. When this flag is set to true, the system permits appending posts with the same post ID multiple times, effectively disabling the default de-duplication behavior. This change enables scenarios where duplicate posts are intentionally displayed, such as in certain pagination or feed refresh cases, providing greater flexibility in how post data is managed and presented. Additionally, the code updates thumbnail generation to avoid initial blank frames and ensures that pagination and post reordering logic respect the new duplication setting.
<!-- kody-pr-summary:end -->