### PR TITLE
Bugfix/social v2 tfm fixes vnk 30 06

### DIFF
--- a/lib/presentation/bloc/media_selection/media_selection_bloc.dart
+++ b/lib/presentation/bloc/media_selection/media_selection_bloc.dart
@@ -9,9 +9,9 @@ import 'package:ism_video_reel_player/presentation/screens/media/media_edit/mode
 import 'package:ism_video_reel_player/presentation/screens/media/media_selection/media_selection_config.dart';
 import 'package:ism_video_reel_player/presentation/screens/media/media_selection/model/media_asset_data.dart';
 import 'package:ism_video_reel_player/utils/utils.dart';
+import 'package:path_provider/path_provider.dart';
 import 'package:permission_handler/permission_handler.dart';
 import 'package:photo_manager/photo_manager.dart' as pm;
-import 'package:pro_video_editor/core/platform/path/path_provider_web.dart';
 import 'package:video_compress/video_compress.dart';
 
 part 'media_selection_event.dart';
@@ -539,22 +539,27 @@ class MediaSelectionBloc
   Future<File?> getThumbnailFile(
     pm.AssetEntity asset,
   ) async {
-    final bytes = await asset.thumbnailDataWithSize(
-      const pm.ThumbnailSize(300, 300),
-      format: pm.ThumbnailFormat.jpeg,
-    );
+    try {
+      final bytes = await asset.thumbnailDataWithSize(
+        const pm.ThumbnailSize(300, 300),
+        format: pm.ThumbnailFormat.jpeg,
+      );
 
-    if (bytes == null) return null;
+      if (bytes == null) return null;
 
-    final directory = await getTemporaryDirectory();
-    final file = File(
-      '${directory.path}/thumbnail_${asset.id.hashCode}_'
-      '${DateTime.now().microsecondsSinceEpoch}.jpg',
-    );
+      final directory = await getTemporaryDirectory();
+      final file = File(
+        '${directory.path}/thumbnail_${asset.id.hashCode}_'
+            '${DateTime.now().microsecondsSinceEpoch}.jpg',
+      );
 
-    await file.writeAsBytes(bytes, flush: true);
+      await file.writeAsBytes(bytes, flush: true);
 
-    return file;
+      return file;
+    } catch (e) {
+      debugPrint('MediaSelectionBloc: getThumbnailFile error: $e');
+      return null;
+    }
   }
 
   // Helper methods for limit validation

--- a/lib/presentation/bloc/media_selection/media_selection_bloc.dart
+++ b/lib/presentation/bloc/media_selection/media_selection_bloc.dart
@@ -11,6 +11,7 @@ import 'package:ism_video_reel_player/presentation/screens/media/media_selection
 import 'package:ism_video_reel_player/utils/utils.dart';
 import 'package:permission_handler/permission_handler.dart';
 import 'package:photo_manager/photo_manager.dart' as pm;
+import 'package:pro_video_editor/core/platform/path/path_provider_web.dart';
 import 'package:video_compress/video_compress.dart';
 
 part 'media_selection_event.dart';
@@ -513,6 +514,7 @@ class MediaSelectionBloc
       pm.AssetEntity asset) async {
     try {
       final file = await asset.file;
+      final thumbnailFileData = await getThumbnailFile(asset);
       if (file == null) return null;
 
       final isVideo = asset.type == pm.AssetType.video;
@@ -523,6 +525,7 @@ class MediaSelectionBloc
         file: file,
         mediaType: isVideo ? SelectedMediaType.video : SelectedMediaType.image,
         width: asset.width,
+        thumbnailPath: thumbnailFileData?.path,
         height: asset.height,
         duration: asset.duration,
         extension: file.path.split('.').last,
@@ -531,6 +534,27 @@ class MediaSelectionBloc
       debugPrint('Error converting asset to MediaAssetData: $e');
       return null;
     }
+  }
+
+  Future<File?> getThumbnailFile(
+    pm.AssetEntity asset,
+  ) async {
+    final bytes = await asset.thumbnailDataWithSize(
+      const pm.ThumbnailSize(300, 300),
+      format: pm.ThumbnailFormat.jpeg,
+    );
+
+    if (bytes == null) return null;
+
+    final directory = await getTemporaryDirectory();
+    final file = File(
+      '${directory.path}/thumbnail_${asset.id.hashCode}_'
+      '${DateTime.now().microsecondsSinceEpoch}.jpg',
+    );
+
+    await file.writeAsBytes(bytes, flush: true);
+
+    return file;
   }
 
   // Helper methods for limit validation


### PR DESCRIPTION
<!-- kody-pr-summary:start -->
This pull request introduces a new method to generate and store thumbnail images for media assets within the media selection process. Specifically, it adds functionality to asynchronously create a JPEG thumbnail from a media asset, save it temporarily on the device, and associate its file path with the media metadata. This enhancement improves the efficiency and user experience by enabling quick access to media previews, likely for display purposes in the UI. The change also includes proper error handling and logging for the thumbnail generation process.
<!-- kody-pr-summary:end -->