### PR TITLE
feat(comments): add option to use base context for comment bottom sheet

### DIFF
--- a/lib/domain/models/comment_config.dart
+++ b/lib/domain/models/comment_config.dart
@@ -4,18 +4,22 @@ class CommentConfig {
   const CommentConfig({
     this.commentUIConfig,
     this.showFloatingcomments = false,
+    this.useBaseContext = false
   });
 
   final CommentUIConfig? commentUIConfig;
   final bool showFloatingcomments;
+  final bool useBaseContext;
 
   CommentConfig copyWith({
     CommentUIConfig? commentUIConfig,
     bool? showFloatingcomments,
+    bool? useBaseContext,
   }) =>
       CommentConfig(
         commentUIConfig: commentUIConfig ?? this.commentUIConfig,
         showFloatingcomments: showFloatingcomments ?? this.showFloatingcomments,
+        useBaseContext: useBaseContext ?? this.useBaseContext,
       );
 }
 

--- a/lib/presentation/screens/posts/ism_post_view.dart
+++ b/lib/presentation/screens/posts/ism_post_view.dart
@@ -8,6 +8,7 @@ import 'package:ism_video_reel_player/core/errors/error_handler.dart';
 import 'package:ism_video_reel_player/data/data.dart';
 import 'package:ism_video_reel_player/di/di.dart';
 import 'package:ism_video_reel_player/domain/domain.dart';
+import 'package:ism_video_reel_player/ism_video_reel_player.dart';
 import 'package:ism_video_reel_player/isr_video_reel_config.dart';
 import 'package:ism_video_reel_player/presentation/presentation.dart';
 import 'package:ism_video_reel_player/res/res.dart';
@@ -1366,7 +1367,9 @@ class _PostViewState extends State<IsmPostView> with TickerProviderStateMixin {
     String? highlightCommentId,
   }) async {
     final result = await showModalBottomSheet<int>(
-      context: context,
+      context: IsrVideoReelConfig.commentConfig.useBaseContext
+          ? IsrVideoReelConfig.getBuildContext?.call() ?? context
+          : context,
       isDismissible: true,
       isScrollControlled: true,
       enableDrag: true,


### PR DESCRIPTION
<!-- kody-pr-summary:start -->
This pull request introduces a new option to specify whether the comment bottom sheet should be displayed using the base context or the current widget context. By adding a `useBaseContext` flag to the comment configuration, it allows for greater flexibility in how the comment UI is presented. When this flag is enabled, the bottom sheet will utilize a globally accessible base context if available, ensuring consistent display behavior across different parts of the app. This enhancement improves the customization and stability of the comment bottom sheet presentation within the video feed interface.
<!-- kody-pr-summary:end -->